### PR TITLE
feat: Supabase backend setup with real deployment data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Supabase connection — get these from your Supabase project dashboard
+# Settings → API → Project URL and service_role key
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/plans/2026-03-05-supabase-backend.md
+++ b/docs/plans/2026-03-05-supabase-backend.md
@@ -1,0 +1,216 @@
+# Supabase Backend — Design Document
+
+**Date:** 2026-03-05
+**Status:** Draft
+**Related issues:** #17 (Supabase proposal), #9 (Dashboard), #10 (Offline sync), #6 (GSheets — superseded)
+
+## Summary
+
+Replace the proposed Google Sheets backend with Supabase (Postgres) as the data layer for LUaid.org. The MVP is a read-only transparency dashboard powered by server-side rendering, with data entered via the Supabase table editor. Real deployment data from Typhoon Emong relief operations (KML export from Google Maps) will seed the database.
+
+## Goals
+
+- Ship a working prototype dashboard with real data that collaborators can share with aid workers
+- Establish a schema that matches real-world relief operation data (validated against KML export of 55 actual deployment points)
+- Keep the architecture simple: SSR fetch → render → cache for offline
+- Design for future expansion (forms, offline sync, real-time) without over-building now
+
+## Decisions
+
+| Decision | Choice | Why |
+|----------|--------|-----|
+| Backend | Supabase (free tier) | Postgres + Auth + Realtime + Storage at zero cost. GSheets has 60 req/min limits, no relational queries, no auth |
+| Data entry (MVP) | Supabase table editor | Fastest path to real data in the prototype. No forms to build yet |
+| Frontend data fetching | Server components (SSR) | Keys stay server-side, rendered HTML cached by service worker for offline, simplest architecture |
+| Primary keys | UUIDs | Future offline sync needs collision-free IDs from multiple devices |
+| Schema design | Deployment-centric | Real KML data shows every aid delivery is a located event. One core table instead of separate deployments/goods/distributions |
+
+## Schema
+
+### Entity Relationship
+
+```
+organizations ──┬──→ donations
+                │
+                └──→ deployments ←── aid_categories
+                         │
+                         └──→ barangays (optional grouping)
+```
+
+### Tables
+
+#### organizations
+Who is doing the work — donors, deployment hubs, or both.
+
+```sql
+CREATE TABLE organizations (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         text NOT NULL,
+  type         text NOT NULL CHECK (type IN ('donor', 'hub', 'both')),
+  municipality text,
+  lat          decimal(9,6),
+  lng          decimal(9,6),
+  created_at   timestamptz DEFAULT now()
+);
+```
+
+Seed data from KML: Waves4Water, Citizens for LU, CURMA, Emerging Islands, FEED/Citizens for LU, Burt Rebuild.
+
+#### aid_categories
+Broad groupings for dashboard rollups.
+
+```sql
+CREATE TABLE aid_categories (
+  id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  icon text
+);
+```
+
+Seed values: Water Filtration, Meals, Relief Goods, Construction Materials, Cleaning Supplies, Drinking Water, Kiddie Packs.
+
+#### barangays
+Geographic aggregation layer for the dashboard's "Aid Distribution Map" section.
+
+```sql
+CREATE TABLE barangays (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         text NOT NULL,
+  municipality text NOT NULL,
+  lat          decimal(9,6),
+  lng          decimal(9,6),
+  population   integer,
+  created_at   timestamptz DEFAULT now()
+);
+```
+
+Barangay coordinates can be derived by clustering nearby deployment points from the KML data, or entered manually from known barangay center coordinates.
+
+#### donations
+Monetary contributions — separate from aid delivery.
+
+```sql
+CREATE TABLE donations (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  amount          decimal(12,2) NOT NULL,
+  date            date NOT NULL,
+  notes           text,
+  created_at      timestamptz DEFAULT now()
+);
+```
+
+No KML source for this — will be entered manually via Supabase table editor using data from the team.
+
+#### deployments
+The core table. Every aid delivery event = one row. Maps 1:1 to KML Placemarks.
+
+```sql
+CREATE TABLE deployments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  aid_category_id uuid NOT NULL REFERENCES aid_categories(id),
+  barangay_id     uuid REFERENCES barangays(id),
+  quantity        integer,
+  unit            text,
+  recipient       text,
+  lat             decimal(9,6),
+  lng             decimal(9,6),
+  date            date,
+  volunteer_count integer,
+  hours           decimal(5,1),
+  notes           text,
+  created_at      timestamptz DEFAULT now()
+);
+```
+
+Real data examples from KML:
+| org | category | quantity | unit | recipient | lat | lng |
+|-----|----------|----------|------|-----------|-----|-----|
+| Waves4Water | Water Filtration | 6 | filters | — | 16.6589 | 120.3312 |
+| Citizens for LU | Meals | 200 | meals | Residents | 16.6912 | 120.3410 |
+| Emerging Islands | Relief Goods | 50 | packs | Residents (kiddie packs) | 16.7340 | 120.3433 |
+| Burt Rebuild | Construction Materials | 3 | sheets | Aileen Paguirigan | 16.7334 | 120.3667 |
+
+### Dashboard Query Mapping
+
+| Dashboard Section | Query |
+|---|---|
+| Total Donations (₱) | `SELECT SUM(amount) FROM donations` |
+| Total Beneficiaries | `SELECT SUM(quantity) FROM deployments WHERE unit IN ('meals','packs','goods',...)` |
+| Volunteer Count | `SELECT SUM(volunteer_count) FROM deployments` |
+| Donations by Org | `SELECT o.name, SUM(d.amount) FROM donations d JOIN organizations o ... GROUP BY o.id` |
+| Deployment Hubs | `SELECT o.name, o.municipality, COUNT(*) FROM deployments d JOIN organizations o ... GROUP BY o.id` |
+| Goods by Category | `SELECT ac.name, SUM(d.quantity) FROM deployments d JOIN aid_categories ac ... GROUP BY ac.id` |
+| Aid Map (pins) | `SELECT lat, lng, quantity, unit FROM deployments` |
+| Aid Map (by barangay) | `SELECT b.name, b.municipality, SUM(d.quantity) FROM deployments d JOIN barangays b ... GROUP BY b.id` |
+
+## Integration Architecture
+
+```
+┌─────────────────────┐    SSR fetch     ┌──────────────┐
+│   Next.js App       │ ──────────────→  │   Supabase   │
+│ (Server Components) │                  │  (Postgres)  │
+│                     │ ← JSON ────────  │              │
+└──────────┬──────────┘                  └──────────────┘
+           │
+           │  rendered HTML
+           ▼
+┌─────────────────────┐
+│   Service Worker     │  caches pages for offline
+│     (Serwist)        │
+└─────────────────────┘
+```
+
+### Files to create
+
+```
+src/
+  lib/
+    supabase.ts       # Server-side Supabase client (service role key)
+    queries.ts         # Typed query functions for each dashboard section
+```
+
+### Environment variables
+
+```
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<key>
+```
+
+Server-side only. Never exposed to the browser. Added to `.env.local` (gitignored) and Vercel environment settings.
+
+### Dependencies
+
+```
+@supabase/supabase-js  # Only new dependency
+```
+
+## Seed Data
+
+The KML file (`Emong_relief_operations.kml`) contains 55 real deployment points from Typhoon Emong relief operations across 6 organizations. A one-time seed script will:
+
+1. Parse the KML XML
+2. Create organization records for each `<Folder>`
+3. Map Placemark names to aid categories (e.g., "Filters" → Water Filtration, "meals served" → Meals)
+4. Insert deployment records with coordinates, quantities, and units
+
+This gives the prototype real data from day one.
+
+## What This Enables Next
+
+Once this MVP is live and in collaborators' hands:
+
+1. **Dashboard UI (#9)** — build the frontend against real Supabase data
+2. **Offline sync (#10)** — add IndexedDB caching and background sync
+3. **Forms (#11)** — authenticated forms to submit data (replace Supabase table editor)
+4. **Maps (#7)** — Leaflet rendering of deployment coordinates
+5. **Barangay triage (#15)** — status board using barangay + deployment data
+
+## Out of Scope (for now)
+
+- Supabase Auth (no user-facing forms yet)
+- Real-time subscriptions (SSR with revalidation is sufficient for MVP)
+- Row-Level Security policies (add when auth is introduced)
+- Image/photo storage (wireframe mentions on-site photos — future feature)
+- Timeline/phases view (CMS content, not database)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@serwist/next": "^9.5.6",
+        "@supabase/supabase-js": "^2.98.0",
         "next": "16.1.6",
         "next-intl": "^4.8.3",
         "react": "19.2.3",
@@ -2858,6 +2859,86 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.98.0",
+        "@supabase/functions-js": "2.98.0",
+        "@supabase/postgrest-js": "2.98.0",
+        "@supabase/realtime-js": "2.98.0",
+        "@supabase/storage-js": "2.98.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.13",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.13.tgz",
@@ -3504,11 +3585,16 @@
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -3535,6 +3621,15 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -6407,6 +6502,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/icu-minify": {
@@ -9603,7 +9707,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -10156,6 +10259,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@serwist/next": "^9.5.6",
+    "@supabase/supabase-js": "^2.98.0",
     "next": "16.1.6",
     "next-intl": "^4.8.3",
     "react": "19.2.3",

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,123 @@
+import { supabase } from "./supabase";
+
+export async function getTotalDonations() {
+  const { data, error } = await supabase
+    .from("donations")
+    .select("amount");
+
+  if (error) throw error;
+  return data.reduce((sum, row) => sum + Number(row.amount), 0);
+}
+
+export async function getTotalBeneficiaries() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("quantity");
+
+  if (error) throw error;
+  return data.reduce((sum, row) => sum + (row.quantity ?? 0), 0);
+}
+
+export async function getVolunteerCount() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("volunteer_count");
+
+  if (error) throw error;
+  return data.reduce((sum, row) => sum + (row.volunteer_count ?? 0), 0);
+}
+
+export async function getDonationsByOrganization() {
+  const { data, error } = await supabase
+    .from("donations")
+    .select("amount, organizations(name)");
+
+  if (error) throw error;
+
+  const grouped = data.reduce<Record<string, number>>((acc, row) => {
+    const name = (row.organizations as unknown as { name: string })?.name ?? "Unknown";
+    acc[name] = (acc[name] ?? 0) + Number(row.amount);
+    return acc;
+  }, {});
+
+  return Object.entries(grouped)
+    .map(([name, amount]) => ({ name, amount }))
+    .sort((a, b) => b.amount - a.amount);
+}
+
+export async function getDeploymentHubs() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("organization_id, organizations(name, municipality)");
+
+  if (error) throw error;
+
+  const grouped = data.reduce<
+    Record<string, { name: string; municipality: string; count: number }>
+  >((acc, row) => {
+    const org = row.organizations as unknown as { name: string; municipality: string };
+    const id = row.organization_id;
+    if (!acc[id]) {
+      acc[id] = { name: org?.name ?? "Unknown", municipality: org?.municipality ?? "", count: 0 };
+    }
+    acc[id].count++;
+    return acc;
+  }, {});
+
+  return Object.values(grouped).sort((a, b) => b.count - a.count);
+}
+
+export async function getGoodsByCategory() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("quantity, aid_categories(name, icon)");
+
+  if (error) throw error;
+
+  const grouped = data.reduce<
+    Record<string, { name: string; icon: string | null; total: number }>
+  >((acc, row) => {
+    const cat = row.aid_categories as unknown as { name: string; icon: string | null };
+    const name = cat?.name ?? "Unknown";
+    if (!acc[name]) {
+      acc[name] = { name, icon: cat?.icon ?? null, total: 0 };
+    }
+    acc[name].total += row.quantity ?? 0;
+    return acc;
+  }, {});
+
+  return Object.values(grouped).sort((a, b) => b.total - a.total);
+}
+
+export async function getDeploymentMapPoints() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("lat, lng, quantity, unit, organizations(name), aid_categories(name)")
+    .not("lat", "is", null);
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getBeneficiariesByBarangay() {
+  const { data, error } = await supabase
+    .from("deployments")
+    .select("quantity, barangays(name, municipality)")
+    .not("barangay_id", "is", null);
+
+  if (error) throw error;
+
+  const grouped = data.reduce<
+    Record<string, { name: string; municipality: string; beneficiaries: number }>
+  >((acc, row) => {
+    const brgy = row.barangays as unknown as { name: string; municipality: string };
+    const key = brgy?.name ?? "Unknown";
+    if (!acc[key]) {
+      acc[key] = { name: brgy?.name ?? "Unknown", municipality: brgy?.municipality ?? "", beneficiaries: 0 };
+    }
+    acc[key].beneficiaries += row.quantity ?? 0;
+    return acc;
+  }, {});
+
+  return Object.values(grouped).sort((a, b) => b.beneficiaries - a.beneficiaries);
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables"
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,69 @@
+-- LUaid.org — Supabase Schema
+-- Run this in the Supabase SQL Editor to create all tables.
+
+-- Organizations: donors, deployment hubs, or both
+CREATE TABLE organizations (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         text NOT NULL,
+  type         text NOT NULL CHECK (type IN ('donor', 'hub', 'both')),
+  municipality text,
+  lat          decimal(9,6),
+  lng          decimal(9,6),
+  created_at   timestamptz DEFAULT now()
+);
+
+-- Aid categories: broad groupings for dashboard rollups
+CREATE TABLE aid_categories (
+  id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  icon text
+);
+
+-- Barangays: geographic aggregation layer
+CREATE TABLE barangays (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         text NOT NULL,
+  municipality text NOT NULL,
+  lat          decimal(9,6),
+  lng          decimal(9,6),
+  population   integer,
+  created_at   timestamptz DEFAULT now()
+);
+
+-- Donations: monetary contributions
+CREATE TABLE donations (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  amount          decimal(12,2) NOT NULL,
+  date            date NOT NULL,
+  notes           text,
+  created_at      timestamptz DEFAULT now()
+);
+
+-- Deployments: every aid delivery event (core table)
+CREATE TABLE deployments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  aid_category_id uuid NOT NULL REFERENCES aid_categories(id),
+  barangay_id     uuid REFERENCES barangays(id),
+  quantity        integer,
+  unit            text,
+  recipient       text,
+  lat             decimal(9,6),
+  lng             decimal(9,6),
+  date            date,
+  volunteer_count integer,
+  hours           decimal(5,1),
+  notes           text,
+  created_at      timestamptz DEFAULT now()
+);
+
+-- Seed aid categories
+INSERT INTO aid_categories (name, icon) VALUES
+  ('Water Filtration', 'droplet'),
+  ('Meals', 'utensils'),
+  ('Relief Goods', 'package'),
+  ('Construction Materials', 'hammer'),
+  ('Cleaning Supplies', 'sparkles'),
+  ('Drinking Water', 'glass-water'),
+  ('Kiddie Packs', 'baby');

--- a/supabase/seed-kml.ts
+++ b/supabase/seed-kml.ts
@@ -1,0 +1,260 @@
+/**
+ * KML Seed Script
+ *
+ * Parses the Emong Relief Operations KML export and inserts
+ * real deployment data into Supabase.
+ *
+ * Usage:
+ *   npx tsx supabase/seed-kml.ts <path-to-kml-file>
+ *
+ * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local
+ */
+
+import { readFileSync } from "fs";
+import { createClient } from "@supabase/supabase-js";
+
+// Load env from .env.local
+const envFile = readFileSync(".env.local", "utf-8");
+const env: Record<string, string> = {};
+for (const line of envFile.split("\n")) {
+  const match = line.match(/^(\w+)=(.+)$/);
+  if (match) env[match[1]] = match[2].trim();
+}
+
+const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+
+// KML folder name → organization info
+const ORG_MAP: Record<string, { name: string; type: string; municipality: string }> = {
+  "Waves4Water Filter Deployment": { name: "Waves4Water", type: "hub", municipality: "San Juan" },
+  "Citizens for LU Soup Kitchen": { name: "Citizens for LU", type: "both", municipality: "San Juan" },
+  "CURMA": { name: "CURMA", type: "hub", municipality: "San Juan" },
+  "Emerging Islands": { name: "Emerging Islands", type: "hub", municipality: "San Juan" },
+  "FEED/Citizens for LU": { name: "FEED / Citizens for LU", type: "both", municipality: "San Juan" },
+  "Burt Rebuild": { name: "Burt Rebuild", type: "hub", municipality: "San Juan" },
+};
+
+// Map KML placemark names to aid categories
+function categorize(name: string): { category: string; quantity: number | null; unit: string; recipient: string | null } {
+  const lower = name.toLowerCase();
+
+  // Water filters: "6 Filters", "1 Filter"
+  const filterMatch = name.match(/(\d+)\s*filter/i);
+  if (filterMatch) {
+    return { category: "Water Filtration", quantity: parseInt(filterMatch[1]), unit: "filters", recipient: null };
+  }
+
+  // Meals: "Residents - 200 meals served", "209 meals served"
+  const mealMatch = name.match(/(\d+)\s*meals?/i);
+  if (mealMatch) {
+    return { category: "Meals", quantity: parseInt(mealMatch[1]), unit: "meals", recipient: extractRecipient(name) };
+  }
+
+  // Dalikan (cooking stoves)
+  const dalikanMatch = name.match(/(\d+)\s*[Dd]alikan/);
+  if (dalikanMatch) {
+    return { category: "Relief Goods", quantity: parseInt(dalikanMatch[1]), unit: "dalikan", recipient: extractRecipient(name) };
+  }
+
+  // Drinking water: "6 Cases drinking water"
+  const waterMatch = name.match(/(\d+)\s*[Cc]ases?\s*(drinking\s*water|bottled\s*water|water\s*bottles)/i);
+  if (waterMatch) {
+    return { category: "Drinking Water", quantity: parseInt(waterMatch[1]), unit: "cases", recipient: extractRecipient(name) };
+  }
+
+  // Kiddie packs
+  const kiddieMatch = name.match(/(\d+)\s*kiddie\s*packs?/i);
+  if (kiddieMatch) {
+    return { category: "Kiddie Packs", quantity: parseInt(kiddieMatch[1]), unit: "packs", recipient: extractRecipient(name) };
+  }
+
+  // Corrugated sheets: "Aileen Paguirigan - 3 Corrugated sheet"
+  const sheetMatch = name.match(/(\d+)\s*[Cc]orrugated/);
+  if (sheetMatch) {
+    const recipientMatch = name.match(/^(.+?)\s*-\s*\d+/);
+    return {
+      category: "Construction Materials",
+      quantity: parseInt(sheetMatch[1]),
+      unit: "sheets",
+      recipient: recipientMatch ? recipientMatch[1].trim() : null,
+    };
+  }
+
+  // Construction supplies: "LUSC - Construction Supplies for 15 Schools"
+  if (lower.includes("construction supplies")) {
+    return { category: "Construction Materials", quantity: null, unit: "supplies", recipient: name };
+  }
+
+  // Relief goods/packs: "Residents - 162 Relief goods", "50 Relief packs"
+  const reliefMatch = name.match(/(\d+)\s*[Rr]elief\s*(goods|packs?)/);
+  if (reliefMatch) {
+    return { category: "Relief Goods", quantity: parseInt(reliefMatch[1]), unit: "packs", recipient: extractRecipient(name) };
+  }
+
+  // Cleaning materials
+  if (lower.includes("cleaning")) {
+    return { category: "Cleaning Supplies", quantity: null, unit: "supplies", recipient: null };
+  }
+
+  // Fallback
+  return { category: "Relief Goods", quantity: null, unit: "items", recipient: extractRecipient(name) };
+}
+
+function extractRecipient(name: string): string | null {
+  // "Residents - 200 meals served" → "Residents"
+  // "Katuparan Producers community - 60 Meals served" → "Katuparan Producers community"
+  const match = name.match(/^(.+?)\s*-\s*\d+/);
+  if (match && !match[1].toLowerCase().includes("resident")) {
+    return match[1].trim();
+  }
+  return null;
+}
+
+// Simple XML parser — extracts Folders and Placemarks from KML
+function parseKml(xml: string) {
+  const folders: { name: string; placemarks: { name: string; description: string; lng: number; lat: number }[] }[] = [];
+
+  const folderRegex = /<Folder>([\s\S]*?)<\/Folder>/g;
+  let folderMatch;
+
+  while ((folderMatch = folderRegex.exec(xml)) !== null) {
+    const folderContent = folderMatch[1];
+    const folderName = folderContent.match(/<name>(.*?)<\/name>/)?.[1] ?? "Unknown";
+
+    const placemarks: { name: string; description: string; lng: number; lat: number }[] = [];
+    const placemarkRegex = /<Placemark>([\s\S]*?)<\/Placemark>/g;
+    let pmMatch;
+
+    while ((pmMatch = placemarkRegex.exec(folderContent)) !== null) {
+      const pm = pmMatch[1];
+      const name = pm.match(/<name>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?<\/name>/)?.[1] ?? "";
+      const desc = pm.match(/<description>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/description>/)?.[1] ?? "";
+      const coords = pm.match(/<coordinates>\s*([-\d.]+),([-\d.]+)/);
+
+      if (coords) {
+        placemarks.push({
+          name,
+          description: desc,
+          lng: parseFloat(coords[1]),
+          lat: parseFloat(coords[2]),
+        });
+      }
+    }
+
+    folders.push({ name: folderName, placemarks });
+  }
+
+  return folders;
+}
+
+async function main() {
+  const kmlPath = process.argv[2];
+  if (!kmlPath) {
+    console.error("Usage: npx tsx supabase/seed-kml.ts <path-to-kml-file>");
+    process.exit(1);
+  }
+
+  const xml = readFileSync(kmlPath, "utf-8");
+  const folders = parseKml(xml);
+
+  console.log(`Parsed ${folders.length} folders from KML\n`);
+
+  // Fetch aid categories
+  const { data: categories, error: catError } = await supabase
+    .from("aid_categories")
+    .select("id, name");
+  if (catError) throw catError;
+
+  const categoryMap = new Map(categories.map((c) => [c.name, c.id]));
+
+  // Insert organizations and deployments
+  let totalDeployments = 0;
+
+  for (const folder of folders) {
+    const orgInfo = ORG_MAP[folder.name];
+    if (!orgInfo) {
+      console.warn(`Unknown org folder: "${folder.name}", skipping`);
+      continue;
+    }
+
+    // Insert organization
+    const { data: org, error: orgError } = await supabase
+      .from("organizations")
+      .upsert({ name: orgInfo.name, type: orgInfo.type, municipality: orgInfo.municipality }, { onConflict: "name" })
+      .select("id")
+      .single();
+
+    if (orgError) {
+      // If upsert fails (no unique constraint on name), try insert
+      const { data: insertedOrg, error: insertError } = await supabase
+        .from("organizations")
+        .insert({ name: orgInfo.name, type: orgInfo.type, municipality: orgInfo.municipality })
+        .select("id")
+        .single();
+      if (insertError) throw insertError;
+      console.log(`  Created org: ${orgInfo.name} (${insertedOrg.id})`);
+
+      // Insert deployments for this org
+      for (const pm of folder.placemarks) {
+        const parsed = categorize(pm.name);
+        const categoryId = categoryMap.get(parsed.category);
+
+        if (!categoryId) {
+          console.warn(`  Unknown category: "${parsed.category}" for "${pm.name}"`);
+          continue;
+        }
+
+        const { error: depError } = await supabase.from("deployments").insert({
+          organization_id: insertedOrg.id,
+          aid_category_id: categoryId,
+          quantity: parsed.quantity,
+          unit: parsed.unit,
+          recipient: parsed.recipient,
+          lat: pm.lat,
+          lng: pm.lng,
+          notes: pm.description || null,
+        });
+
+        if (depError) {
+          console.error(`  Failed to insert deployment: ${pm.name}`, depError);
+        } else {
+          totalDeployments++;
+        }
+      }
+    } else {
+      console.log(`  Created org: ${orgInfo.name} (${org.id})`);
+
+      for (const pm of folder.placemarks) {
+        const parsed = categorize(pm.name);
+        const categoryId = categoryMap.get(parsed.category);
+
+        if (!categoryId) {
+          console.warn(`  Unknown category: "${parsed.category}" for "${pm.name}"`);
+          continue;
+        }
+
+        const { error: depError } = await supabase.from("deployments").insert({
+          organization_id: org.id,
+          aid_category_id: categoryId,
+          quantity: parsed.quantity,
+          unit: parsed.unit,
+          recipient: parsed.recipient,
+          lat: pm.lat,
+          lng: pm.lng,
+          notes: pm.description || null,
+        });
+
+        if (depError) {
+          console.error(`  Failed to insert deployment: ${pm.name}`, depError);
+        } else {
+          totalDeployments++;
+        }
+      }
+    }
+
+    console.log(`  → ${folder.placemarks.length} placemarks processed\n`);
+  }
+
+  console.log(`Done! Inserted ${totalDeployments} deployment records.`);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Add Supabase as the data backend, replacing the Google Sheets approach (#17)
- Schema includes 5 tables: organizations, aid_categories, barangays, donations, deployments
- Deployment-centric design validated against real KML data from Typhoon Emong relief ops (55 deployment points across 6 orgs)
- Server-side Supabase client and typed query functions for all dashboard sections
- KML seed script to parse and load real deployment data
- Design document with full rationale

## Files
- `src/lib/supabase.ts` — server-side Supabase client
- `src/lib/queries.ts` — typed query functions for dashboard
- `supabase/schema.sql` — full schema + seed aid categories
- `supabase/seed-kml.ts` — KML parser for real deployment data
- `.env.example` — env var template for contributors
- `docs/plans/2026-03-05-supabase-backend.md` — design document

## Test plan
- [x] Schema created and running in Supabase
- [x] KML seed script successfully inserted 55 real deployment records
- [x] Build passes with no errors