### PR TITLE
docs: add architecture and setup guides, update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,19 @@ LUaid.org is an open-source Progressive Web App for disaster relief operations i
 ## Architecture
 
 - **Frontend**: Next.js (App Router) + TypeScript (strict mode), hosted on Vercel
-- **Database**: Supabase (Postgres + Auth + Realtime + Storage) — proposed, pending team approval; current prototype uses Google Sheets
+- **Database**: Supabase (Postgres) — server-side only via service role key, never exposed to browser
 - **CMS**: WordPress backend at cms.LUaid.org (REST API for content)
-- **Maps**: Leaflet + OpenStreetMap — proposed, pending team approval
-- **PWA**: Service workers for offline caching, IndexedDB for local data, background sync
+- **Maps**: Leaflet + OpenStreetMap (planned — Issue #7)
+- **PWA**: Serwist service worker for offline caching, IndexedDB for local data (planned)
+- **Testing**: Vitest + React Testing Library
 
-## Contributing Context
+See `docs/architecture.md` for system design details and schema overview.
 
-This is a collaborative open-source project. The main repo is `r0droald/LUaid`. We work on forks and submit PRs for review.
+## Contributing
 
-- `origin` → personal fork (Jaskey15/LUaid)
-- `upstream` → main repo (r0droald/LUaid)
-- Feature branches: `feat/<name>`, `fix/<name>`
-- PRs go from fork branches → upstream main
+Main repo: `r0droald/LUaid`. Feature branches (`feat/<name>`, `fix/<name>`) → PR to `main`.
+
+See `docs/setup.md` for local development setup.
 
 ## Key Constraints
 
@@ -27,35 +27,25 @@ This is a collaborative open-source project. The main repo is `r0droald/LUaid`. 
 - **Offline-first**: Everything must work without internet. Cache aggressively, sync when online.
 - **Non-technical users**: Volunteers, writers, and relief coordinators use this. Keep UX simple.
 - **Multilingual**: Must support English, Filipino, and Ilocano at minimum.
+- **Minimal dependencies**: Every dependency is a liability in disaster scenarios.
 
 ## Code Conventions
 
-- TypeScript (strict mode) — all source, test, and config files use `.ts`/`.tsx`
+- TypeScript strict mode — all source, test, and config files use `.ts`/`.tsx`
 - App Router (not Pages Router)
 - Tailwind CSS for styling
-- Components in `src/components/`
-- Keep dependencies minimal — every dependency is a liability in disaster scenarios
+- Server components for data fetching (keys stay server-side)
+- Components in `src/components/`, query functions in `src/lib/queries.ts`
 
 ## Commands
 
 ```bash
-# Dev server (Turbopack — no service worker in dev)
-npm run dev
-
-# Production build (webpack — generates service worker)
-npm run build
-
-# Start production server
-npm run start
-
-# Lint
-npm run lint
-
-# Run tests (once)
-npm test
-
-# Run tests (watch mode)
-npm run test:watch
+npm run dev          # Dev server (Turbopack — no service worker)
+npm run build        # Production build (webpack — generates service worker)
+npm run start        # Start production server
+npm run lint         # ESLint
+npm test             # Run tests (Vitest, once)
+npm run test:watch   # Run tests (watch mode)
 ```
 
 ## Project Structure
@@ -63,26 +53,34 @@ npm run test:watch
 ```
 src/
   app/
-    [locale]/       # Locale-based routing (en, fil, ilo)
-      layout.tsx    # Root layout with NextIntlClientProvider
-      page.tsx      # Homepage
-      ~offline/     # Offline fallback page (Serwist)
-    globals.css     # Global styles (Tailwind)
-    sw.ts           # Service worker source (Serwist)
-  components/       # Reusable UI components
-  hooks/            # Custom React hooks
-  lib/              # Utilities, API clients, helpers
+    [locale]/         # Locale-based routing (en, fil, ilo)
+      layout.tsx      # Root layout with NextIntlClientProvider
+      page.tsx        # Homepage
+      ~offline/       # Offline fallback page (Serwist)
+    globals.css       # Global styles (Tailwind)
+    sw.ts             # Service worker source (Serwist)
+  components/         # Reusable UI components
+  hooks/              # Custom React hooks
+  lib/
+    supabase.ts       # Server-side Supabase client
+    queries.ts        # Typed query functions for dashboard sections
   i18n/
-    routing.ts      # Locale definitions
-    request.ts      # Server-side i18n config
-    types.ts        # next-intl AppConfig type augmentation
-  middleware.ts     # Locale detection/redirect
-messages/           # Translation files (en.json, fil.json, ilo.json)
+    routing.ts        # Locale definitions
+    request.ts        # Server-side i18n config
+    types.ts          # next-intl AppConfig type augmentation
+  middleware.ts       # Locale detection/redirect
+supabase/
+  schema.sql          # Database schema (5 tables)
+  seed-kml.ts         # KML parser → Supabase seed script
+data/                 # Real relief operation data (KML exports)
+messages/             # Translation files (en.json, fil.json, ilo.json)
+docs/                 # Architecture, setup guide, plans
 public/
-  manifest.json     # PWA manifest
-  icons/            # PWA icons
+  manifest.json       # PWA manifest
+  icons/              # PWA icons
 ```
 
-## Open Issues Tracking
+## Lessons Learned
 
-See the GitHub Issues on the main repo for the current backlog. MVP milestone covers: scaffold (#8), dashboard (#9), offline sync (#10), maps (#7), forms (#11), CMS (#13), multilanguage (#12).
+- `Problem:` Supabase JS client returns nested relations as `unknown` types → `Rule:` Cast join results explicitly (e.g., `row.organizations as unknown as { name: string }`) in query functions
+- `Problem:` Serwist only generates service worker on webpack builds → `Rule:` Use `npm run build` (not dev server) to test offline behavior

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,106 @@
+# Architecture
+
+## System Overview
+
+LUaid is a Next.js PWA that fetches data from Supabase (Postgres) via server components and caches rendered HTML for offline use. Content comes from a WordPress CMS. The architecture prioritizes simplicity — SSR fetch, render, cache — with room to grow into forms, real-time updates, and offline sync.
+
+```
+┌─────────────────────┐    SSR fetch     ┌──────────────┐
+│   Next.js App       │ ──────────────→  │   Supabase   │
+│ (Server Components) │                  │  (Postgres)  │
+│                     │ ← JSON ────────  │              │
+└──────────┬──────────┘                  └──────────────┘
+           │
+           │  rendered HTML
+           ▼
+┌─────────────────────┐
+│   Service Worker     │  caches pages for offline
+│     (Serwist)        │
+└─────────────────────┘
+```
+
+**Data flow:** Server components call query functions in `src/lib/queries.ts` → Supabase client (`src/lib/supabase.ts`) fetches from Postgres using the service role key → rendered HTML is served to the browser → Serwist service worker caches pages for offline access.
+
+The Supabase service role key is server-side only and never reaches the browser.
+
+## Database Schema
+
+Five tables, centered around the `deployments` table which represents individual aid delivery events.
+
+```
+organizations ──┬──→ donations
+                │
+                └──→ deployments ←── aid_categories
+                         │
+                         └──→ barangays (optional grouping)
+```
+
+### Tables
+
+| Table | Purpose | Key Fields |
+|-------|---------|------------|
+| `organizations` | Donors and deployment hubs | name, type (donor/hub/both), municipality, lat/lng |
+| `aid_categories` | Lookup table for aid types | name, icon (7 pre-seeded categories) |
+| `barangays` | Geographic aggregation | name, municipality, lat/lng, population |
+| `donations` | Monetary contributions | organization_id, amount, date |
+| `deployments` | Aid delivery events (core table) | organization_id, aid_category_id, barangay_id, quantity, unit, recipient, lat/lng, date |
+
+All primary keys are UUIDs — designed for future offline sync where multiple devices need collision-free IDs.
+
+Full SQL schema: `supabase/schema.sql`
+
+### Query Functions
+
+`src/lib/queries.ts` provides 8 typed functions that map to dashboard sections:
+
+| Function | Returns |
+|----------|---------|
+| `getTotalDonations()` | Sum of all donation amounts |
+| `getTotalBeneficiaries()` | Sum of deployment quantities |
+| `getVolunteerCount()` | Sum of volunteer counts |
+| `getDonationsByOrganization()` | Donations grouped by org, sorted by amount |
+| `getDeploymentHubs()` | Deployment count per org + municipality |
+| `getGoodsByCategory()` | Quantities grouped by aid category |
+| `getDeploymentMapPoints()` | Lat/lng points with metadata for map pins |
+| `getBeneficiariesByBarangay()` | Beneficiary totals grouped by barangay |
+
+## Seed Data
+
+Real deployment data from Typhoon Emong relief operations is stored in `data/Emong_relief_operations.kml` — 55 deployment points across 6 organizations. The seed script (`supabase/seed-kml.ts`) parses the KML and inserts organizations + deployments into Supabase.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Backend | Supabase (free tier) | Postgres + Auth + Realtime at zero cost. Google Sheets had 60 req/min limits, no relational queries, no auth |
+| Data fetching | Server components (SSR) | Keys stay server-side, rendered HTML cached by service worker |
+| Primary keys | UUIDs | Collision-free IDs for future offline sync from multiple devices |
+| Schema design | Deployment-centric | Real KML data shows every aid delivery is a located event — one core table |
+| Data entry (MVP) | Supabase table editor | No forms to build yet, fastest path to real data |
+
+## Internationalization
+
+Locale-based routing via `next-intl`: `/en/`, `/fil/`, `/ilo/`. Translation files in `messages/`. Server-side locale detection in `middleware.ts` redirects to the appropriate locale.
+
+## What's Built vs Planned
+
+**Built:**
+- Next.js PWA scaffold with Serwist service worker
+- Locale-based routing (en, fil, ilo)
+- Supabase schema, client, and query functions
+- KML seed script with real Typhoon Emong data
+- Vitest testing framework
+
+**Planned (see GitHub Issues):**
+- Dashboard UI (#9) — frontend consuming the query functions
+- Offline sync (#10) — IndexedDB caching + background sync
+- Data entry forms (#11) — replace Supabase table editor
+- Map visualization (#7) — Leaflet rendering of deployment coordinates
+- Barangay triage (#15) — status board for prioritizing aid
+- CMS integration (#13) — WordPress content via REST API
+- Supabase Auth + RLS — add when user-facing forms are built
+
+## Further Reading
+
+- `docs/plans/` — Design documents for each implementation phase
+- `docs/project-history.md` — Origin story and project direction

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,83 @@
+# Local Development Setup
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+- A [Supabase](https://supabase.com) account (free tier)
+
+## 1. Clone and Install
+
+```bash
+git clone https://github.com/r0droald/LUaid.git
+cd LUaid
+npm install
+```
+
+## 2. Set Up Supabase
+
+1. Create a new project at [supabase.com/dashboard](https://supabase.com/dashboard)
+2. Go to **SQL Editor** and paste the contents of `supabase/schema.sql` — this creates all tables and seeds the aid categories
+3. Go to **Settings → API** and copy your **Project URL** and **service_role key**
+
+## 3. Configure Environment
+
+```bash
+cp .env.example .env.local
+```
+
+Edit `.env.local` with your Supabase credentials:
+
+```
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+```
+
+This file is gitignored. Never commit real keys.
+
+## 4. Seed the Database (Optional)
+
+The repo includes real deployment data from Typhoon Emong relief operations. To seed your Supabase database:
+
+```bash
+npx tsx supabase/seed-kml.ts data/Emong_relief_operations.kml
+```
+
+This parses the KML file and inserts 6 organizations and ~55 deployment records.
+
+**Note:** The schema must be applied first (step 2) — the seed script expects the `aid_categories` table to already be populated.
+
+## 5. Run the Dev Server
+
+```bash
+npm run dev
+```
+
+Opens at [http://localhost:3000](http://localhost:3000). The dev server uses Turbopack and does not generate a service worker.
+
+To test offline/PWA behavior, use a production build:
+
+```bash
+npm run build && npm run start
+```
+
+## 6. Run Tests
+
+```bash
+npm test            # Single run
+npm run test:watch  # Watch mode
+```
+
+## 7. Lint
+
+```bash
+npm run lint
+```
+
+## Common Issues
+
+| Issue | Fix |
+|-------|-----|
+| `SUPABASE_URL is not defined` | Make sure `.env.local` exists and has both variables set |
+| Seed script fails with "relation does not exist" | Run `supabase/schema.sql` in the Supabase SQL Editor first |
+| Service worker not working in dev | Expected — Serwist only generates the SW on `npm run build` (webpack). Use a production build to test offline. |


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Updated to reflect active Supabase integration (no longer "proposed"), depersonalized contributing context, added project structure for `supabase/`, `data/`, `src/lib/` files, added Lessons Learned section
- **docs/architecture.md** — New high-level system design doc covering data flow, schema overview, query function reference, key decisions, and built vs planned status
- **docs/setup.md** — New step-by-step local development guide covering Supabase setup, environment config, seed script, and common troubleshooting

## Test plan

- [ ] Verify all file paths referenced in docs exist on main
- [ ] Walk through setup.md steps against a fresh clone