### PR TITLE
docs: add original architecture from staging branch

### DIFF
--- a/docs/original-architecture/front-end-spec.md
+++ b/docs/original-architecture/front-end-spec.md
@@ -1,0 +1,214 @@
+# LUaid PWA UI/UX Specification
+
+## Introduction
+This document defines the user experience goals, information architecture, user flows, and visual design specifications for the LUaid PWA’s user interface. It serves as the foundation for visual design and frontend development, ensuring a cohesive and user-centered experience.
+
+---
+
+## Overall UX Goals & Principles
+
+### Target User Personas
+- **Volunteer:** Submits field reports offline, often in low-connectivity, high-stress environments.
+- **Community Contributor:** Writes and translates articles, may have limited technical experience.
+- **Admin/Approver:** Reviews and manages multilingual submissions, configures site, ensures content quality.
+- **Donor/NGO Staff:** Views dashboards and maps to monitor relief progress and transparency.
+- **Disaster-Affected End User:** Accesses content offline, needs clear, up-to-date information in their language.
+
+### Usability Goals
+- **Offline-first:** All critical tasks (form submission, content reading) must work without connectivity.
+- **Fast onboarding:** New users can complete core tasks (e.g., submit a report, read an article) within 5 minutes.
+- **Role clarity:** Users always know what actions are available to them.
+- **Error prevention:** Clear validation, feedback, and confirmation for all actions.
+- **Accessibility:** Interfaces are usable in low-light, low-bandwidth, and for users with partial visual impairment.
+
+### Core Design Principles
+1. **Clarity over cleverness:** Prioritize clear communication and guidance.
+2. **Progressive disclosure:** Show only what’s needed, when it’s needed.
+3. **Consistent patterns:** Use familiar UI patterns throughout the application.
+4. **Immediate feedback:** Every action should have a clear, immediate response.
+5. **Accessible by default:** Design for all users from the start.
+
+---
+
+## Information Architecture (IA)
+
+### Site Map / Screen Inventory
+```mermaid
+graph TD
+    A[Home] --> B[Dashboard]
+    A --> C[Blog/Articles]
+    A --> D[Map]
+    A --> E[Submit Report]
+    A --> F[Login/Account]
+    F --> F1[Contributor Workflow]
+    F --> F2[Admin/Approval]
+    C --> C1[Article Reader]
+    C --> C2[Language Switcher]
+```
+
+### Navigation Structure
+**Primary Navigation:** Home, Dashboard, Blog/Articles, Map, Submit Report, Account/Login
+
+**Secondary Navigation:** Language Switcher, Role-based workflow tabs (Contributor, Admin)
+
+**Breadcrumb Strategy:** Shown for nested content (e.g., Article > Edit > Approve)
+
+---
+
+## User Flows
+
+### Volunteer: Submit Field Report (Offline)
+- **User Goal:** Submit a field report even when offline
+- **Entry Points:** Home, Dashboard, direct link
+- **Success Criteria:** Report is saved locally and queued for sync
+
+```mermaid
+flowchart TD
+    Start([Start]) --> FillForm[Fill Out Report Form]
+    FillForm --> Submit[Submit]
+    Submit -->|Offline| LocalSave[Save Locally]
+    LocalSave --> Queue[Queue for Sync]
+    Queue --> Feedback[Show Sync Status]
+    Feedback --> End([End])
+```
+
+**Edge Cases & Error Handling:**
+- Device storage full
+- User closes app before sync
+- Form validation errors
+
+---
+
+### Contributor: Write/Translate Article
+- **User Goal:** Submit or translate an article for review
+- **Entry Points:** Account/Login > Contributor Workflow
+- **Success Criteria:** Article is submitted and visible for approval
+
+---
+
+### Admin/Approver: Review Submissions
+- **User Goal:** Approve or reject content
+- **Entry Points:** Account/Login > Admin/Approval
+- **Success Criteria:** Content is published or sent back for revision
+
+---
+
+### Donor/NGO: View Dashboard & Map
+- **User Goal:** See up-to-date relief data and deployment zones
+- **Entry Points:** Home, Dashboard, Map
+- **Success Criteria:** Data loads quickly, fallback to cached if offline
+
+---
+
+### End User: Read Articles Offline
+- **User Goal:** Access information in their language, even offline
+- **Entry Points:** Home, Blog/Articles
+- **Success Criteria:** Content is readable, language switcher works, update status shown
+
+---
+
+## Wireframes & Mockups
+- Primary design files to be created in Figma (link to be added)
+- Key screens: Home, Dashboard, Article Reader, Report Form, Map, Contributor Workflow, Admin Panel
+- Layouts: Mobile-first, responsive, uncluttered
+
+---
+
+## Component Library / Design System
+- **Design System Approach:** Custom, with reusable components for forms, cards, navigation, status banners, and language switcher
+- **Core Components:**
+  - Button (primary, secondary, disabled)
+  - Form fields (text, select, file upload)
+  - Card (dashboard, article preview)
+  - Modal/Dialog (confirmations, errors)
+  - Banner (staging/prod, sync status)
+  - Language Switcher
+  - Map Widget
+  - Dashboard Chart
+
+---
+
+## Branding & Style Guide
+- **Brand Guidelines:** LUaid logo, disaster transparency theme, culturally neutral
+- **Color Palette:**
+  - Primary: #1976D2 (Blue) – navigation, buttons
+  - Secondary: #263238 (Charcoal) – backgrounds, text
+  - Accent: #FFC107 (Amber) – highlights, status
+  - Success: #388E3C (Green)
+  - Warning: #FFA000 (Orange)
+  - Error: #D32F2F (Red)
+  - Neutral: #FFFFFF, #F5F5F5, #B0BEC5 (White, light gray, gray)
+- **Typography:**
+  - Primary: Inter, Arial, sans-serif
+  - Large, legible, high-contrast
+- **Iconography:**
+  - Material Icons or similar, optimized for tap targets
+- **Spacing & Layout:**
+  - 8px grid, responsive breakpoints for mobile, tablet, desktop
+
+---
+
+## Accessibility Requirements
+- **Standard:** WCAG 2.1 AA
+- **Visual:**
+  - High color contrast for text and UI
+  - Focus indicators on all interactive elements
+  - Adjustable text size
+- **Interaction:**
+  - Full keyboard navigation
+  - Screen reader support
+  - Large tap targets
+- **Content:**
+  - Alt text for all images
+  - Clear heading structure
+  - Proper form labels
+- **Testing:**
+  - Use Lighthouse, axe, and manual testing on real devices
+
+---
+
+## Responsiveness Strategy
+- **Breakpoints:**
+  - Mobile: 320–600px (primary target)
+  - Tablet: 601–1024px
+  - Desktop: 1025–1440px
+  - Wide: 1441px+
+- **Adaptation Patterns:**
+  - Mobile-first layouts
+  - Collapsible navigation
+  - Content prioritization for small screens
+  - Touch-friendly interactions
+
+---
+
+## Animation & Micro-interactions
+- Minimal, purposeful animations (e.g., button press, sync status)
+- Avoid heavy transitions for performance and battery
+- Feedback for form submission, sync, and errors
+
+---
+
+## Performance Considerations
+- **Page Load:** <2s on 3G
+- **Interaction Response:** <100ms for UI feedback
+- **Animation FPS:** 60fps for all transitions
+- **Design Strategies:**
+  - Lazy load images and data
+  - Cache-first for offline
+  - Optimize assets for low bandwidth
+
+---
+
+## Next Steps
+1. Review with stakeholders
+2. Create/update visual designs in Figma
+3. Prepare for handoff to frontend development
+4. Address any open questions or decisions
+
+**Design Handoff Checklist:**
+- [x] All user flows documented
+- [x] Component inventory complete
+- [x] Accessibility requirements defined
+- [x] Responsive strategy clear
+- [x] Brand guidelines incorporated
+- [x] Performance goals established

--- a/docs/original-architecture/fullstack-architecture.md
+++ b/docs/original-architecture/fullstack-architecture.md
@@ -1,0 +1,251 @@
+# Full-Stack Architecture: LUaid PWA Disaster Relief Platform
+
+## System Overview
+
+**Project:** LUaid PWA - Offline-Ready Disaster Relief Platform  
+**Architecture Type:** Multi-tier PWA with external service integrations  
+**Primary Goal:** Enable disaster relief coordination in low-connectivity environments  
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    LUaid PWA Ecosystem                        │
+├─────────────────────────────────────────────────────────────────┤
+│  Frontend Layer (Vercel)                                      │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐ │
+│  │   Main PWA      │  │   Staging       │  │   Documentation │ │
+│  │  luaid.org      │  │staging.luaid.org│  │ docs.luaid.org  │ │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│  External Service Layer                                        │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐ │
+│  │  WordPress CMS  │  │  Google Sheets  │  │  Google Maps    │ │
+│  │  cms.luaid.org  │  │   (Dashboard)   │  │   (Deployment)  │ │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│  Client-Side Storage Layer                                     │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐ │
+│  │   IndexedDB     │  │   Service       │  │   Background    │ │
+│  │  (Offline Data) │  │   Worker Cache  │  │   Sync Queue    │ │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Frontend Architecture (Vite + React PWA)
+
+### Technology Stack
+- **Framework:** React 18+ with TypeScript
+- **Build Tool:** Vite with PWA plugin
+- **Hosting:** Vercel (free tier)
+- **State Management:** React Context + Local Storage
+- **Routing:** React Router with offline-first routing
+- **UI Components:** Custom components optimized for mobile
+
+### PWA Features
+- **Service Worker:** Workbox for caching strategies
+- **Manifest:** Installable app with offline capabilities
+- **Background Sync:** Queue form submissions when offline
+- **Push Notifications:** For content updates and alerts
+
+### Component Architecture
+```
+src/
+├── components/
+│   ├── dashboard/          # Real-time dashboard components
+│   ├── forms/             # Volunteer form components
+│   ├── cms/               # Editorial workflow components
+│   ├── maps/              # Google Maps integration
+│   └── shared/            # Reusable UI components
+├── hooks/
+│   ├── useOfflineSync/    # Background sync logic
+│   ├── useSheetsAPI/      # Google Sheets integration
+│   ├── useWordPressAPI/   # WordPress REST API
+│   └── useLocalStorage/   # IndexedDB management
+├── services/
+│   ├── sheetsService.js   # Google Sheets API wrapper
+│   ├── wordpressService.js # WordPress API wrapper
+│   ├── syncService.js     # Offline sync management
+│   └── cacheService.js    # Service worker cache logic
+└── utils/
+    ├── offlineUtils.js    # Offline detection & handling
+    ├── languageUtils.js   # Multilingual support
+    └── validationUtils.js # Form validation
+```
+
+## Backend Services Integration
+
+### 1. Google Sheets (Dashboard & Data Storage)
+**Purpose:** Real-time dashboard metrics and volunteer form storage
+
+**API Integration:**
+- Google Sheets API v4
+- Service account authentication
+- Real-time data fetching with caching
+- Background sync for form submissions
+
+**Data Structure:**
+```
+Dashboard Sheets:
+├── relief_metrics/         # Real-time relief statistics
+├── volunteer_reports/      # Form submissions (synced)
+├── deployment_zones/       # Geographic relief data
+└── user_management/        # User roles and permissions
+```
+
+### 2. WordPress CMS (Content Management)
+**Purpose:** Multilingual articles, editorial workflow, user management
+
+**Hosting:** Free-tier WordPress hosting
+**Domain:** cms.luaid.org
+
+**WordPress Configuration:**
+- Custom REST API endpoints
+- Multilingual plugin (WPML or Polylang)
+- Role-based access control
+- Custom post types for articles
+- Media optimization for offline caching
+
+**API Endpoints:**
+```
+/api/v1/articles/          # Article CRUD operations
+/api/v1/users/             # User management
+/api/v1/categories/        # Content categorization
+/api/v1/media/             # Optimized media files
+/api/v1/languages/         # Multilingual content
+```
+
+### 3. Google Maps Integration
+**Purpose:** Visualize relief deployment zones and field operations
+
+**Implementation:**
+- Google Maps JavaScript API
+- Custom markers for deployment zones
+- Offline map tiles caching
+- Real-time location updates (when online)
+
+## Data Flow Architecture
+
+### Online Mode
+```
+User Action → PWA → API Calls → External Services → Response → Cache Update
+```
+
+### Offline Mode
+```
+User Action → PWA → Local Storage → Background Sync Queue → Sync when Online
+```
+
+### Sync Strategy
+1. **Immediate Sync:** Dashboard data and critical updates
+2. **Background Sync:** Form submissions and non-critical data
+3. **Conflict Resolution:** Timestamp-based merging
+4. **Retry Logic:** Exponential backoff for failed syncs
+
+## Security Architecture
+
+### Authentication & Authorization
+- **WordPress User Management:** Centralized user accounts
+- **Role-Based Access:** Volunteers, Contributors, Approvers, Admins
+- **JWT Tokens:** For API authentication
+- **HTTPS Enforcement:** All communications encrypted
+
+### Data Privacy
+- **Minimal PII:** Only essential personal information collected
+- **Local Storage Encryption:** Sensitive data encrypted in IndexedDB
+- **Data Retention:** Configurable cleanup policies
+- **GDPR Compliance:** User consent and data portability
+
+## Performance Optimization
+
+### Caching Strategy
+```
+Service Worker Cache:
+├── Static Assets (1 week)
+├── API Responses (1 hour)
+├── Dashboard Data (15 minutes)
+├── Articles (1 day)
+└── Language Files (1 month)
+```
+
+### Offline-First Design
+- **Critical Path:** Core functionality works offline
+- **Progressive Enhancement:** Enhanced features when online
+- **Battery Optimization:** Minimal background processing
+- **Storage Management:** Automatic cleanup of old data
+
+## Deployment Architecture
+
+### Environment Strategy
+```
+Development → Staging → Production
+     ↓           ↓          ↓
+  Local Dev   staging    luaid.org
+              .luaid.org
+```
+
+### CI/CD Pipeline
+- **GitHub Actions:** Automated testing and deployment
+- **Branch Strategy:** staging (approval) → production
+- **Rollback Capability:** Quick deployment rollback
+- **Health Monitoring:** Uptime and performance tracking
+
+## Scalability Considerations
+
+### Horizontal Scaling
+- **CDN:** Vercel's global edge network
+- **API Rate Limiting:** Prevent abuse and ensure fair usage
+- **Database Sharding:** WordPress multisite for regional content
+- **Caching Layers:** Multiple cache levels for performance
+
+### Regional Deployment
+- **Content Localization:** Region-specific articles and data
+- **Language Support:** English, Filipino, Ilocano
+- **Cultural Adaptation:** Region-specific UI/UX patterns
+- **Network Optimization:** Local CDN endpoints
+
+## Monitoring & Analytics
+
+### Performance Metrics
+- **Core Web Vitals:** LCP, FID, CLS
+- **Offline Usage:** Service worker effectiveness
+- **Sync Success Rate:** Background sync reliability
+- **User Engagement:** Form completion rates
+
+### Error Tracking
+- **Client-Side Errors:** JavaScript error monitoring
+- **API Failures:** External service availability
+- **Sync Failures:** Background sync error tracking
+- **User Feedback:** In-app error reporting
+
+## Risk Mitigation
+
+### Technical Risks
+- **External Service Dependencies:** Fallback mechanisms
+- **Offline Data Loss:** Redundant storage strategies
+- **API Rate Limits:** Intelligent request throttling
+- **Browser Compatibility:** Progressive enhancement
+
+### Operational Risks
+- **Content Moderation:** Editorial workflow controls
+- **Data Accuracy:** Validation and verification processes
+- **User Training:** Comprehensive documentation
+- **Support Infrastructure:** Community-driven support
+
+## Future Architecture Considerations
+
+### Phase 2 Enhancements
+- **Advanced Analytics:** Real-time impact measurement
+- **AI Integration:** Content recommendation and automation
+- **Mobile App:** Native app development
+- **IoT Integration:** Sensor data for disaster monitoring
+
+### Phase 3 Scalability
+- **Microservices:** Break down into smaller services
+- **Event-Driven Architecture:** Real-time event processing
+- **Advanced Caching:** Redis and CDN optimization
+- **Machine Learning:** Predictive analytics for relief coordination
+
+---
+
+This architecture provides a robust foundation for the LUaid PWA while maintaining the cost-effective, offline-first approach required for disaster relief environments.

--- a/docs/original-architecture/project-brief.md
+++ b/docs/original-architecture/project-brief.md
@@ -1,0 +1,60 @@
+# Project Brief: LUaid PWA – Offline-Ready Disaster Relief Platform
+
+## Project Name
+LUaid PWA: Offline-Ready Disaster Relief Platform
+
+## Objectives
+- Build an installable PWA hosted on Vercel using Vite + React.
+- Sync real-time dashboards from Google Sheets.
+- Enable offline access and form submissions via IndexedDB and Workbox.
+- Integrate multilingual WordPress content via REST API.
+- Embed a custom Google Map to visualize relief deployment zones.
+- Provide volunteer reporting forms with Background Sync.
+- Implement GitHub branching: staging (for approval) and production.
+- Establish a CMS with editorial permissions (volunteers, writers, approvers, admins).
+- Cache Filipino, Ilocano, and English content for offline use.
+- Ensure resilience and usability in low-connectivity environments.
+
+## Key Stakeholders
+- Rod (Technical Lead & Architect)
+- LUaid.org Management Team (decision makers)
+- Community volunteers and field reporters submitting forms
+- Contributing writers and Editorial staff managing CMS workflows
+- NGOs and donors monitoring dashboards
+- End users accessing cached content in disaster zones
+
+## Timeline
+
+**Phase 1 (MVP):**
+- Scaffold PWA
+- Dashboard-Google Sheets API integration
+- Custom map embed
+- Staging deploy
+- MVP production launch
+
+**Phase 2:**
+- Offline form submission to Google Sheets
+- User login and authentication
+- WordPress user management and CMS backend
+- CMS REST sync
+
+**Phase 3:**
+- Multilingual setup
+- Editorial permissions
+- Approval workflow
+
+**Phase 4:**
+- Contributor documentation
+- User guides
+
+## Specific Requirements and Notes
+- Use subdomains: staging.luaid.org, cms.luaid.org, docs.luaid.org.
+- Installable PWA front-end hosted on Vercel, backend from Google Sheets and WordPress.
+- Google Sheets used for dashboard metrics and volunteer form storage.
+- WordPress used for multilingual blogging and editorial management.
+- Approval workflow for content and articles.
+- GitHub Projects used to manage sharded tasks and PRD prompts.
+- Offline reports stored locally, synced to Sheets with Background Sync API.
+- Agentic workflow via BMAD + Cursor for modular task generation and approval.
+- Placeholder landing site remains unaffected during MVP staging buildout.
+- Design and content strategy optimized for offline mobile access, fast/convenient submission of forms/reports in the field, and informative dashboards for transparency and accountability. 


### PR DESCRIPTION
## Summary
- Pulls Rod's original project brief, fullstack architecture, and front-end UI/UX spec from the `staging` branch into `docs/original-architecture/`
- Preserves the original vision and design decisions for reference as the project evolves

## Files
- `docs/original-architecture/project-brief.md` — Project objectives, stakeholders, phased timeline
- `docs/original-architecture/fullstack-architecture.md` — System design, data flow, caching strategy
- `docs/original-architecture/front-end-spec.md` — UX goals, user personas, wireframes, design system