### PR TITLE
feat: wire i18n into dashboard components + language switcher

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -19,9 +19,14 @@
     "goodsPurchased": "Goods Purchased",
     "aidDistributionMap": "Aid Distribution Map",
     "liveMap": "Live Map",
+    "mapPlaceholder": "Interactive map coming soon",
+    "barangayPrefix": "Barangay",
     "deployments": "deployments",
     "beneficiaries": "beneficiaries",
     "online": "Online",
-    "lastUpdated": "Last Updated"
+    "lastUpdated": "Last Updated",
+    "loading": "Loading dashboard\u2026",
+    "loadError": "Failed to load dashboard data",
+    "retry": "Retry"
   }
 }

--- a/public/locales/fil/translation.json
+++ b/public/locales/fil/translation.json
@@ -19,9 +19,14 @@
     "goodsPurchased": "Goods Purchased",
     "aidDistributionMap": "Aid Distribution Map",
     "liveMap": "Live Map",
+    "mapPlaceholder": "Interactive map coming soon",
+    "barangayPrefix": "Barangay",
     "deployments": "deployments",
     "beneficiaries": "beneficiaries",
     "online": "Online",
-    "lastUpdated": "Last Updated"
+    "lastUpdated": "Last Updated",
+    "loading": "Loading dashboard\u2026",
+    "loadError": "Failed to load dashboard data",
+    "retry": "Retry"
   }
 }

--- a/public/locales/ilo/translation.json
+++ b/public/locales/ilo/translation.json
@@ -19,9 +19,14 @@
     "goodsPurchased": "Goods Purchased",
     "aidDistributionMap": "Aid Distribution Map",
     "liveMap": "Live Map",
+    "mapPlaceholder": "Interactive map coming soon",
+    "barangayPrefix": "Barangay",
     "deployments": "deployments",
     "beneficiaries": "beneficiaries",
     "online": "Online",
-    "lastUpdated": "Last Updated"
+    "lastUpdated": "Last Updated",
+    "loading": "Loading dashboard\u2026",
+    "loadError": "Failed to load dashboard data",
+    "retry": "Retry"
   }
 }

--- a/src/components/AidDistributionMap.tsx
+++ b/src/components/AidDistributionMap.tsx
@@ -1,22 +1,26 @@
+import { useTranslation } from "react-i18next";
+
 type Props = {
   barangays: { name: string; municipality: string; beneficiaries: number }[];
 };
 
 export default function AidDistributionMap({ barangays }: Props) {
+  const { t } = useTranslation();
+
   return (
     <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-neutral-50">
-          Aid Distribution Map
+          {t("Dashboard.aidDistributionMap")}
         </h3>
         <span className="rounded-full bg-error/20 px-3 py-1 text-xs font-medium text-error">
-          Live Map
+          {t("Dashboard.liveMap")}
         </span>
       </div>
 
       <div className="mb-6 flex h-48 items-center justify-center rounded-lg bg-base/30">
         <p className="text-sm text-neutral-400/60">
-          Interactive map coming soon
+          {t("Dashboard.mapPlaceholder")}
         </p>
       </div>
 
@@ -39,14 +43,14 @@ export default function AidDistributionMap({ barangays }: Props) {
                 />
               </svg>
               <span className="text-neutral-400">
-                Barangay {brgy.name}, {brgy.municipality}
+                {t("Dashboard.barangayPrefix")} {brgy.name}, {brgy.municipality}
               </span>
             </div>
             <div className="text-right">
               <span className="font-bold text-error">
                 {brgy.beneficiaries.toLocaleString()}
               </span>
-              <span className="ml-1 text-xs text-neutral-400/60">beneficiaries</span>
+              <span className="ml-1 text-xs text-neutral-400/60">{t("Dashboard.beneficiaries")}</span>
             </div>
           </div>
         ))}

--- a/src/components/DeploymentHubs.tsx
+++ b/src/components/DeploymentHubs.tsx
@@ -1,12 +1,16 @@
+import { useTranslation } from "react-i18next";
+
 type Props = {
   hubs: { name: string; municipality: string; count: number }[];
 };
 
 export default function DeploymentHubs({ hubs }: Props) {
+  const { t } = useTranslation();
+
   return (
     <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
-        Deployment Hubs
+        {t("Dashboard.deploymentHubs")}
       </h3>
       <div className="divide-y divide-neutral-400/20">
         {hubs.map((hub) => (
@@ -20,7 +24,7 @@ export default function DeploymentHubs({ hubs }: Props) {
             </div>
             <div className="text-right">
               <p className="text-2xl font-bold text-neutral-50">{hub.count}</p>
-              <p className="text-xs text-neutral-400/60">deployments</p>
+              <p className="text-xs text-neutral-400/60">{t("Dashboard.deployments")}</p>
             </div>
           </div>
         ))}

--- a/src/components/DonationsByOrg.tsx
+++ b/src/components/DonationsByOrg.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 type Props = {
   donations: { name: string; amount: number }[];
 };
@@ -14,12 +16,13 @@ const BAR_COLORS = [
 ];
 
 export default function DonationsByOrg({ donations }: Props) {
+  const { t } = useTranslation();
   const total = donations.reduce((sum, d) => sum + d.amount, 0);
 
   return (
     <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
-        Donations Received per Organization
+        {t("Dashboard.donationsByOrg")}
       </h3>
       <div className="space-y-4">
         {donations.map((org, i) => {

--- a/src/components/GoodsByCategory.tsx
+++ b/src/components/GoodsByCategory.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 type Props = {
   categories: { name: string; icon: string | null; total: number }[];
 };
@@ -13,10 +15,12 @@ const FALLBACK_ICONS: Record<string, string> = {
 };
 
 export default function GoodsByCategory({ categories }: Props) {
+  const { t } = useTranslation();
+
   return (
     <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
-        Goods Purchased
+        {t("Dashboard.goodsPurchased")}
       </h3>
       <div className="grid grid-cols-2 gap-3">
         {categories.map((cat) => (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,38 @@
 import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router";
+import { supportedLocales, type Locale } from "../i18n";
+
+const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  fil: "Filipino",
+  ilo: "Ilocano",
+};
 
 export default function Header() {
   const { t } = useTranslation();
+  const { locale } = useParams<{ locale: string }>();
+  const navigate = useNavigate();
+
+  const handleLocaleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    navigate(`/${e.target.value}`);
+  };
 
   return (
     <header className="border-b border-neutral-400/20 bg-secondary">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <span className="text-xl font-bold text-white">LUaid.org</span>
         <div className="flex items-center gap-4">
-          <span className="text-sm text-neutral-400">🌐 English</span>
+          <select
+            value={locale}
+            onChange={handleLocaleChange}
+            className="rounded-lg border border-neutral-400/20 bg-secondary px-3 py-1.5 text-sm text-neutral-400"
+          >
+            {supportedLocales.map((loc) => (
+              <option key={loc} value={loc}>
+                {LOCALE_LABELS[loc]}
+              </option>
+            ))}
+          </select>
           <a
             href="#"
             className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-white hover:bg-primary/80"

--- a/src/components/StatusFooter.tsx
+++ b/src/components/StatusFooter.tsx
@@ -1,4 +1,7 @@
+import { useTranslation } from "react-i18next";
+
 export default function StatusFooter() {
+  const { t } = useTranslation();
   const now = new Date();
   const time = now.toLocaleTimeString("en-PH", {
     hour: "2-digit",
@@ -10,10 +13,10 @@ export default function StatusFooter() {
     <footer className="mt-6 flex items-center gap-6 rounded-xl border-t border-neutral-400/20 bg-secondary px-6 py-4 text-sm text-neutral-400">
       <span className="flex items-center gap-2">
         <span className="h-2 w-2 rounded-full bg-success" />
-        Online
+        {t("Dashboard.online")}
       </span>
       <span className="flex items-center gap-2">
-        🕐 Last Updated: {time}
+        {t("Dashboard.lastUpdated")}: {time}
       </span>
     </footer>
   );

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 type Props = {
   totalDonations: number;
   totalBeneficiaries: number;
@@ -9,11 +11,13 @@ export default function SummaryCards({
   totalBeneficiaries,
   volunteerCount,
 }: Props) {
+  const { t } = useTranslation();
+
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
       <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
-          Total Donations
+          {t("Dashboard.totalDonations")}
         </p>
         <p className="mt-2 text-3xl font-bold text-success">
           ₱{totalDonations.toLocaleString()}
@@ -22,7 +26,7 @@ export default function SummaryCards({
 
       <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
-          Total Beneficiaries
+          {t("Dashboard.totalBeneficiaries")}
         </p>
         <p className="mt-2 text-3xl font-bold text-neutral-50">
           {totalBeneficiaries.toLocaleString()}
@@ -31,7 +35,7 @@ export default function SummaryCards({
 
       <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
-          Volunteer Count
+          {t("Dashboard.volunteerCount")}
         </p>
         <p className="mt-2 text-3xl font-bold text-neutral-50">
           {volunteerCount.toLocaleString()}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import Header from "@/components/Header";
 import SummaryCards from "@/components/SummaryCards";
 import DonationsByOrg from "@/components/DonationsByOrg";
@@ -27,6 +28,7 @@ type DashboardData = {
 };
 
 export function DashboardPage() {
+  const { t } = useTranslation();
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,7 +78,7 @@ export function DashboardPage() {
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-neutral-400">Loading dashboard…</p>
+        <p className="text-neutral-400">{t("Dashboard.loading")}</p>
       </div>
     );
   }
@@ -84,12 +86,12 @@ export function DashboardPage() {
   if (error || !data) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4">
-        <p className="text-error">Failed to load dashboard data</p>
+        <p className="text-error">{t("Dashboard.loadError")}</p>
         <button
           onClick={fetchData}
           className="rounded-lg bg-primary px-4 py-2 text-sm text-white hover:bg-primary/80"
         >
-          Retry
+          {t("Dashboard.retry")}
         </button>
       </div>
     );

--- a/tests/unit/components/AidDistributionMap.test.tsx
+++ b/tests/unit/components/AidDistributionMap.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import AidDistributionMap from "@/components/AidDistributionMap";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("AidDistributionMap", () => {
   it("renders barangay names and beneficiary counts", () => {

--- a/tests/unit/components/DeploymentHubs.test.tsx
+++ b/tests/unit/components/DeploymentHubs.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import DeploymentHubs from "@/components/DeploymentHubs";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("DeploymentHubs", () => {
   it("renders hub names with deployment counts", () => {

--- a/tests/unit/components/DonationsByOrg.test.tsx
+++ b/tests/unit/components/DonationsByOrg.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import DonationsByOrg from "@/components/DonationsByOrg";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("DonationsByOrg", () => {
   it("renders organization names and amounts", () => {

--- a/tests/unit/components/GoodsByCategory.test.tsx
+++ b/tests/unit/components/GoodsByCategory.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import GoodsByCategory from "@/components/GoodsByCategory";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("GoodsByCategory", () => {
   it("renders category names and totals", () => {

--- a/tests/unit/components/Header.test.tsx
+++ b/tests/unit/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
 import Header from "@/components/Header";
 
 vi.mock("react-i18next", () => ({
@@ -7,12 +8,38 @@ vi.mock("react-i18next", () => ({
     t: (key: string) => key,
     i18n: { changeLanguage: vi.fn() },
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
+function renderHeader(locale = "en") {
+  return render(
+    <MemoryRouter initialEntries={[`/${locale}`]}>
+      <Routes>
+        <Route path="/:locale" element={<Header />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe("Header", () => {
-  it("renders logo, language display, and volunteer button", () => {
-    render(<Header />);
+  it("renders logo, language switcher, and volunteer button", () => {
+    renderHeader();
     expect(screen.getByText("LUaid.org")).toBeInTheDocument();
     expect(screen.getByText("Navigation.volunteer")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("shows all three language options", () => {
+    renderHeader();
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("English");
+    expect(options[1]).toHaveTextContent("Filipino");
+    expect(options[2]).toHaveTextContent("Ilocano");
+  });
+
+  it("selects the current locale", () => {
+    renderHeader("fil");
+    expect(screen.getByRole("combobox")).toHaveValue("fil");
   });
 });

--- a/tests/unit/components/StatusFooter.test.tsx
+++ b/tests/unit/components/StatusFooter.test.tsx
@@ -1,11 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import StatusFooter from "@/components/StatusFooter";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("StatusFooter", () => {
   it("renders online status and timestamp", () => {
     render(<StatusFooter />);
-    expect(screen.getByText("Online")).toBeInTheDocument();
-    expect(screen.getByText(/Last Updated/)).toBeInTheDocument();
+    expect(screen.getByText("Dashboard.online")).toBeInTheDocument();
+    expect(screen.getByText(/Dashboard\.lastUpdated/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/SummaryCards.test.tsx
+++ b/tests/unit/components/SummaryCards.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import SummaryCards from "@/components/SummaryCards";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
 
 describe("SummaryCards", () => {
   it("renders all three summary values", () => {
@@ -14,5 +21,18 @@ describe("SummaryCards", () => {
     expect(screen.getByText("₱2,847,500")).toBeInTheDocument();
     expect(screen.getByText("12,847")).toBeInTheDocument();
     expect(screen.getByText("234")).toBeInTheDocument();
+  });
+
+  it("renders translated labels", () => {
+    render(
+      <SummaryCards
+        totalDonations={0}
+        totalBeneficiaries={0}
+        volunteerCount={0}
+      />
+    );
+    expect(screen.getByText("Dashboard.totalDonations")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard.totalBeneficiaries")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard.volunteerCount")).toBeInTheDocument();
   });
 });

--- a/tests/unit/pages/DashboardPage.test.tsx
+++ b/tests/unit/pages/DashboardPage.test.tsx
@@ -13,12 +13,19 @@ vi.mock("@/lib/queries", () => ({
   getBeneficiariesByBarangay: vi.fn(),
 }));
 
-// Mock react-i18next (Header uses it)
+// Mock react-i18next
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: { changeLanguage: vi.fn() },
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+// Mock react-router (Header uses useParams/useNavigate)
+vi.mock("react-router", () => ({
+  useParams: () => ({ locale: "en" }),
+  useNavigate: () => vi.fn(),
 }));
 
 import {
@@ -58,7 +65,7 @@ describe("DashboardPage", () => {
 
   it("shows loading state initially", () => {
     render(<DashboardPage />);
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByText("Dashboard.loading")).toBeInTheDocument();
   });
 
   it("renders dashboard components after data loads", async () => {
@@ -86,7 +93,7 @@ describe("DashboardPage", () => {
     expect(screen.getByText(/Catbangen/)).toBeInTheDocument();
 
     // StatusFooter
-    expect(screen.getByText("Online")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard.online")).toBeInTheDocument();
   });
 
   it("renders error state with retry button on fetch failure", async () => {
@@ -95,9 +102,9 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+      expect(screen.getByText("Dashboard.loadError")).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dashboard.retry" })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Wire `useTranslation()` + `t()` calls into all 7 dashboard components and DashboardPage, replacing hardcoded English strings with translation keys
- Add functional language switcher dropdown to Header (English / Filipino / Ilocano) that navigates via URL path
- Add 5 missing translation keys (`loading`, `loadError`, `retry`, `mapPlaceholder`, `barangayPrefix`) to all 3 locale files

## Test plan
- [x] All 14 tests pass across 8 test files
- [x] Clean production build (no TypeScript errors)
- [x] Visual check: language switcher renders and navigates between `/en`, `/fil`, `/ilo`
- [ ] Verify translated strings appear when switching (currently only a few fil/ilo strings differ — see #34)

Ref: #34 (tracks native Filipino/Ilocano translations)