### PR TITLE
feat(ui): warm community aesthetic upgrade

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -17,16 +17,16 @@ Source of truth: `src/index.css` via Tailwind v4 `@theme inline`.
 
 | Token | Hex | Usage |
 |-------|-----|-------|
-| `primary` | `#1976D2` | Buttons, links, navigation highlights |
-| `secondary` | `#263238` | Card backgrounds |
-| `accent` | `#FFC107` | Highlights, status indicators |
+| `primary` | `#0E9AA7` | Buttons, links, navigation highlights (warm teal) |
+| `secondary` | `#24282e` | Card backgrounds (warm slate) |
+| `accent` | `#F0C456` | Highlights, status indicators (soft gold) |
 | `success` | `#388E3C` | Positive values, online status, monetary amounts |
 | `warning` | `#FFA000` | Caution states |
 | `error` | `#D32F2F` | Errors, map markers |
 | `neutral-50` | `#FFFFFF` | Primary text (headings, values) |
-| `neutral-100` | `#F5F5F5` | Secondary text |
-| `neutral-400` | `#B0BEC5` | Muted text, borders, labels |
-| `base` | `#1a252b` | Page background |
+| `neutral-100` | `#F3F0ED` | Secondary text (warm off-white) |
+| `neutral-400` | `#9CA3AF` | Muted text, borders, labels (true gray) |
+| `base` | `#1a1d21` | Page background (warm ink) |
 
 ## Theme
 
@@ -34,13 +34,13 @@ Single dark theme. Dark `bg-base` background with `bg-secondary` card surfaces.
 
 ## Common Patterns
 
-- **Cards:** `rounded-xl border border-neutral-400/20 bg-secondary p-6`
+- **Cards:** `rounded-2xl bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]` with colored `border-l-[3px]` accent bars and `.animate-fade-slide-up` entrance animation
 - **Buttons:** `bg-primary hover:bg-primary/80 text-neutral-50 rounded-lg px-4 py-2`
 - **Opacity variants:** Use `/` syntax — `text-neutral-400/60`, `border-neutral-400/20`, `bg-error/20`
 
 ## Font
 
-Inter Variable loaded locally via `@fontsource-variable/inter` (no CDN — offline-first).
+Nunito Variable loaded locally via `@fontsource-variable/nunito` (no CDN — offline-first). Rounded terminals give approachable personality. Weight 800 for metric/KPI numbers (signature element).
 
 ## Leaflet Override
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "luaid",
       "version": "0.2.0",
       "dependencies": {
-        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/nunito": "^5.2.7",
         "@supabase/supabase-js": "^2.98.0",
         "i18next": "^25.8.14",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2435,10 +2435,10 @@
         }
       }
     },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+    "node_modules/@fontsource-variable/nunito": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/nunito/-/nunito-5.2.7.tgz",
+      "integrity": "sha512-2N8QhatkyKgSUbAGZO2FYLioxA32+RyI1EplVLawbpkGjUeui9Qg9VMrpkCaik1ydjFjfLV+kzQ0cGEsMrMenQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "verify:headed": "npx playwright test --headed"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/nunito": "^5.2.7",
     "@supabase/supabase-js": "^2.98.0",
     "i18next": "^25.8.14",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/components/AidDistributionMap.tsx
+++ b/src/components/AidDistributionMap.tsx
@@ -25,7 +25,7 @@ export default function AidDistributionMap({
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+    <div className="rounded-2xl border-l-[3px] border-success bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-neutral-50">
           {t("Dashboard.aidDistributionMap")}

--- a/src/components/DeploymentHubs.tsx
+++ b/src/components/DeploymentHubs.tsx
@@ -8,7 +8,7 @@ export default function DeploymentHubs({ hubs }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+    <div className="rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.deploymentHubs")}
       </h3>
@@ -23,7 +23,7 @@ export default function DeploymentHubs({ hubs }: Props) {
               <p className="text-sm text-neutral-400">{hub.municipality}</p>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-bold text-neutral-50">{hub.count}</p>
+              <p className="text-2xl font-extrabold text-neutral-50">{hub.count}</p>
               <p className="text-xs text-neutral-400/60">{t("Dashboard.deployments")}</p>
             </div>
           </div>

--- a/src/components/DonationsByOrg.tsx
+++ b/src/components/DonationsByOrg.tsx
@@ -20,7 +20,7 @@ export default function DonationsByOrg({ donations }: Props) {
   const total = donations.reduce((sum, d) => sum + d.amount, 0);
 
   return (
-    <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+    <div className="rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.donationsByOrg")}
       </h3>

--- a/src/components/GoodsByCategory.tsx
+++ b/src/components/GoodsByCategory.tsx
@@ -23,7 +23,7 @@ export default function GoodsByCategory({ categories }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+    <div className="rounded-2xl border-l-[3px] border-accent bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.goodsPurchased")}
       </h3>
@@ -37,7 +37,7 @@ export default function GoodsByCategory({ categories }: Props) {
               {CATEGORY_ICONS[cat.name] || "📋"}
             </p>
             <p className="mt-1 text-sm text-neutral-400">{cat.name}</p>
-            <p className="mt-1 text-lg font-bold text-primary">
+            <p className="mt-1 text-lg font-extrabold text-primary">
               {cat.total.toLocaleString()}
             </p>
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
   };
 
   return (
-    <header className="border-b border-neutral-400/20 bg-secondary">
+    <header className="bg-secondary shadow-[0_2px_8px_rgba(0,0,0,0.3)]">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <Link to={`/${locale}`} className="text-xl font-bold text-white hover:text-neutral-100">Kapwa Help</Link>
         <nav className="hidden items-center gap-1 sm:flex">
@@ -99,7 +99,7 @@ export default function Header() {
           </div>
           <Link
             to={`/${locale}/submit`}
-            className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-white hover:bg-primary/80"
+            className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-white shadow-[0_0_12px_rgba(14,154,167,0.3)] hover:bg-primary/80 hover:shadow-[0_0_16px_rgba(14,154,167,0.4)] transition-all duration-200"
           >
             {t("Navigation.report")}
             {pendingCount > 0 && (

--- a/src/components/NeedsCoordinationMap.tsx
+++ b/src/components/NeedsCoordinationMap.tsx
@@ -36,7 +36,7 @@ export default function NeedsCoordinationMap({ needsPoints }: Props) {
       : needsPoints.filter((p) => p.accessStatus === accessFilter);
 
   return (
-    <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+    <div className="rounded-2xl border-l-[3px] border-error bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-neutral-50">
           {t("Dashboard.needsMap")}

--- a/src/components/NeedsSummaryCards.tsx
+++ b/src/components/NeedsSummaryCards.tsx
@@ -18,11 +18,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
       {/* Active Needs */}
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-5">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-error bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "0ms" } as React.CSSProperties}>
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.activeNeeds")}
         </p>
-        <p className="mt-2 text-3xl font-bold text-error">
+        <p className="mt-2 text-3xl font-extrabold text-error">
           {summary.byStatus.verified}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -31,11 +31,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* In Transit */}
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-5">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-warning bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "60ms" } as React.CSSProperties}>
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.inTransit")}
         </p>
-        <p className="mt-2 text-3xl font-bold text-warning">
+        <p className="mt-2 text-3xl font-extrabold text-warning">
           {summary.byStatus.in_transit}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -44,11 +44,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* Fulfilled */}
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-5">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-success bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "120ms" } as React.CSSProperties}>
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.fulfilled")}
         </p>
-        <p className="mt-2 text-3xl font-bold text-success">
+        <p className="mt-2 text-3xl font-extrabold text-success">
           {summary.byStatus.completed}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -57,11 +57,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* Critical */}
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-5">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-error bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "180ms" } as React.CSSProperties}>
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.criticalNeeds")}
         </p>
-        <p className="mt-2 text-3xl font-bold text-error">
+        <p className="mt-2 text-3xl font-extrabold text-error">
           {summary.critical}
         </p>
         <p className="mt-1 text-xs text-neutral-400">

--- a/src/components/StatusFooter.tsx
+++ b/src/components/StatusFooter.tsx
@@ -10,9 +10,12 @@ export default function StatusFooter() {
   });
 
   return (
-    <footer className="mt-6 flex items-center gap-6 rounded-xl border-t border-neutral-400/20 bg-secondary px-6 py-4 text-sm text-neutral-400">
+    <footer className="mt-6 flex items-center gap-6 rounded-2xl bg-secondary px-6 py-4 text-sm text-neutral-400 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <span className="flex items-center gap-2">
-        <span className="h-2 w-2 rounded-full bg-success" />
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-success" />
+        </span>
         {t("Dashboard.online")}
       </span>
       <span className="flex items-center gap-2">

--- a/src/components/SubmitForm.tsx
+++ b/src/components/SubmitForm.tsx
@@ -210,7 +210,7 @@ export default function SubmitForm() {
           name="contact_name"
           type="text"
           required
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder={t("SubmitForm.contactNamePlaceholder")}
         />
       </div>
@@ -224,7 +224,7 @@ export default function SubmitForm() {
           id="contact_phone"
           name="contact_phone"
           type="tel"
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder={t("SubmitForm.contactPhonePlaceholder")}
         />
       </div>
@@ -239,7 +239,7 @@ export default function SubmitForm() {
           name="barangay_id"
           required
           disabled={loading}
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
         >
           <option value="">
             {loading ? t("SubmitForm.loadingOptions") : t("SubmitForm.barangayPlaceholder")}
@@ -267,7 +267,7 @@ export default function SubmitForm() {
                 required
                 className="peer sr-only"
               />
-              <span className="block rounded-lg border border-neutral-400/20 bg-base px-2 py-2 text-center text-xs peer-checked:border-primary peer-checked:bg-primary/20 peer-checked:text-primary sm:text-sm">
+              <span className="block rounded-xl border border-neutral-400/20 bg-base px-2 py-3 text-center text-xs peer-checked:border-primary peer-checked:bg-primary/20 peer-checked:text-primary sm:text-sm">
                 {t(`SubmitForm.gap_${gap}`)}
               </span>
             </label>
@@ -284,7 +284,7 @@ export default function SubmitForm() {
           id="access_status"
           name="access_status"
           required
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 focus:outline-none focus:ring-1 focus:ring-primary"
         >
           <option value="">{t("SubmitForm.accessPlaceholder")}</option>
           <option value="truck">{t("SubmitForm.accessTruck")}</option>
@@ -310,7 +310,7 @@ export default function SubmitForm() {
                 required
                 className="peer sr-only"
               />
-              <span className="block rounded-lg border border-neutral-400/20 bg-base px-2 py-2 text-center text-xs peer-checked:border-primary peer-checked:bg-primary/20 peer-checked:text-primary sm:text-sm">
+              <span className="block rounded-xl border border-neutral-400/20 bg-base px-2 py-3 text-center text-xs peer-checked:border-primary peer-checked:bg-primary/20 peer-checked:text-primary sm:text-sm">
                 {t(`SubmitForm.urgency${level.charAt(0).toUpperCase() + level.slice(1)}`)}
               </span>
             </label>
@@ -328,7 +328,7 @@ export default function SubmitForm() {
           name="quantity_needed"
           type="number"
           min="1"
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder={t("SubmitForm.quantityPlaceholder")}
         />
       </div>
@@ -343,7 +343,7 @@ export default function SubmitForm() {
           <button
             type="button"
             onClick={requestLocation}
-            className="rounded-lg border border-neutral-400/20 bg-base px-4 py-2.5 text-sm text-neutral-400 hover:border-primary hover:text-neutral-50 transition-colors"
+            className="rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-sm text-neutral-400 hover:border-primary hover:text-neutral-50 transition-colors"
           >
             {t("SubmitForm.shareLocation")}
           </button>
@@ -359,7 +359,7 @@ export default function SubmitForm() {
           id="notes"
           name="notes"
           rows={3}
-          className="mt-1 w-full rounded-lg border border-neutral-400/20 bg-base px-3 py-2 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
+          className="mt-1 w-full rounded-xl border border-neutral-400/20 bg-base px-4 py-3 text-neutral-50 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder={t("SubmitForm.notesPlaceholder")}
         />
       </div>
@@ -371,7 +371,7 @@ export default function SubmitForm() {
       <button
         type="submit"
         disabled={submitting}
-        className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-neutral-50 hover:bg-primary/80 disabled:opacity-50"
+        className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-medium text-neutral-50 shadow-[0_0_12px_rgba(14,154,167,0.3)] hover:bg-primary/80 hover:shadow-[0_0_16px_rgba(14,154,167,0.4)] transition-all duration-200 disabled:opacity-50"
       >
         {submitting ? t("SubmitForm.submitting") : t("SubmitForm.submit")}
       </button>

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -35,14 +35,14 @@ export default function SummaryCards({
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-success bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "0ms" } as React.CSSProperties}>
         <div className="flex items-center justify-between">
           <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
             {t("Dashboard.totalDonations")}
           </p>
           <TrendIcon />
         </div>
-        <p className="mt-2 text-3xl font-bold text-success">
+        <p className="mt-2 text-3xl font-extrabold text-success">
           ₱{totalDonations.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -50,14 +50,14 @@ export default function SummaryCards({
         </p>
       </div>
 
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "60ms" } as React.CSSProperties}>
         <div className="flex items-center justify-between">
           <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
             {t("Dashboard.totalBeneficiaries")}
           </p>
           <TrendIcon />
         </div>
-        <p className="mt-2 text-3xl font-bold text-neutral-50">
+        <p className="mt-2 text-3xl font-extrabold text-neutral-50">
           {totalBeneficiaries.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -65,11 +65,11 @@ export default function SummaryCards({
         </p>
       </div>
 
-      <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "120ms" } as React.CSSProperties}>
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.volunteerCount")}
         </p>
-        <p className="mt-2 text-3xl font-bold text-neutral-50">
+        <p className="mt-2 text-3xl font-extrabold text-neutral-50">
           {volunteerCount.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">

--- a/src/index.css
+++ b/src/index.css
@@ -1,24 +1,54 @@
-@import "@fontsource-variable/inter";
+@import "@fontsource-variable/nunito";
 @import "tailwindcss";
 @import "leaflet/dist/leaflet.css";
 
 @theme inline {
-  --color-primary: #1976D2;
-  --color-secondary: #263238;
-  --color-accent: #FFC107;
+  --color-primary: #0E9AA7;
+  --color-secondary: #24282e;
+  --color-accent: #F0C456;
   --color-success: #388E3C;
   --color-warning: #FFA000;
   --color-error: #D32F2F;
   --color-neutral-50: #FFFFFF;
-  --color-neutral-100: #F5F5F5;
-  --color-neutral-400: #B0BEC5;
-  --color-base: #1a252b;
+  --color-neutral-100: #F3F0ED;
+  --color-neutral-400: #9CA3AF;
+  --color-base: #1a1d21;
 }
 
 body {
   background: var(--color-base);
   color: var(--color-neutral-50);
-  font-family: "Inter Variable", Inter, Arial, sans-serif;
+  font-family: "Nunito Variable", Nunito, Arial, sans-serif;
+}
+
+/* Faint grain texture — registers as "surface" vs "void" */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0.03;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.7' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+/* Staggered card entrance animation */
+@keyframes fadeSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-slide-up {
+  animation: fadeSlideUp 400ms ease-out both;
+  animation-delay: var(--delay, 0ms);
 }
 
 .leaflet-popup-content-wrapper {

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -12,7 +12,7 @@ export function SubmitPage() {
         <h1 className="mb-6 text-center text-2xl font-bold text-neutral-50">
           {t("SubmitForm.title")}
         </h1>
-        <div className="rounded-xl border border-neutral-400/20 bg-secondary p-6">
+        <div className="rounded-2xl border-l-[3px] border-accent bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
           <SubmitForm />
         </div>
       </main>


### PR DESCRIPTION
## Summary

- **Font:** Swap Inter Variable → Nunito Variable (rounded, approachable personality, locally loaded)
- **Palette:** Warm 6 color tokens — teal primary, soft gold accent, warm ink base, true gray neutrals
- **Cards:** Layered box-shadows, `rounded-2xl`, colored semantic accent bars (`border-left`), hover lift, staggered fade-in animation
- **Header:** Shadow replaces hard border, CTA button gets teal glow
- **Forms:** `rounded-xl` inputs with larger padding/touch targets
- **Details:** Faint CSS grain texture overlay, pulsing online indicator dot, `font-extrabold` metric numbers

## Constraints met

- Zero new JS dependencies — everything is CSS-only or a font swap
- Offline-first — font loaded locally via `@fontsource-variable/nunito`
- Single font file (~75KB variable weight)
- OLED-friendly dark theme preserved

## Test plan

- [x] `npm run build` — clean, no TS errors
- [x] `npm run verify` — 16/16 Playwright smoke tests pass
- [x] Visual review across all routes (`/en`, `/en/relief`, `/en/stories`, `/en/submit`)
- [x] Check accent bar colors match semantic intent per card type
- [x] Verify grain texture is barely perceptible, not distracting
- [x] Test hover lift on cards and CTA glow on mobile (touch)