### PR TITLE
Simplify aesthetic upgrade for mobile-first usage

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -34,13 +34,14 @@ Single dark theme. Dark `bg-base` background with `bg-secondary` card surfaces.
 
 ## Common Patterns
 
-- **Cards:** `rounded-2xl bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]` with colored `border-l-[3px]` accent bars and `.animate-fade-slide-up` entrance animation
+- **Cards (default):** `rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]`
+- **Cards (status-coded, Needs page only):** `rounded-2xl border-l-2 border-{status} bg-secondary p-5 shadow-[...]` — use colored left accent only when the color encodes a meaningful status (e.g., error=active, warning=transit, success=fulfilled)
 - **Buttons:** `bg-primary hover:bg-primary/80 text-neutral-50 rounded-lg px-4 py-2`
 - **Opacity variants:** Use `/` syntax — `text-neutral-400/60`, `border-neutral-400/20`, `bg-error/20`
 
 ## Font
 
-Nunito Variable loaded locally via `@fontsource-variable/nunito` (no CDN — offline-first). Rounded terminals give approachable personality. Weight 800 for metric/KPI numbers (signature element).
+Nunito Variable loaded locally via `@fontsource-variable/nunito` (no CDN — offline-first). Rounded terminals give approachable personality. Weight 700 (bold) for metric/KPI numbers.
 
 ## Leaflet Override
 

--- a/docs/plans/2026-03-31-ui-simplification.md
+++ b/docs/plans/2026-03-31-ui-simplification.md
@@ -1,0 +1,52 @@
+# UI Simplification — Selective Rollback of Aesthetic Upgrade
+
+**Date:** 2026-03-31
+**Branch:** `feat/ui-simplification` (off `main`)
+**Context:** The `feat/aesthetic-upgrade` branch introduced visual polish across all pages. Some changes add value (Nunito font, teal palette, button glows, header shadow). Others add unnecessary complexity for a mobile-first disaster relief app. This branch selectively rolls back the overreach.
+
+## Principle
+
+**Left-accent borders only where color encodes status.** Everywhere else, use the uniform subtle border. Animations that delay data visibility get removed entirely.
+
+## Changes
+
+### Remove globally
+- **Grain texture overlay** (`body::after` in index.css) — extra compositing layer for no visual payoff on mobile
+- **fadeSlideUp animation** (keyframes + `.animate-fade-slide-up` class in index.css) — 400ms delay before data is readable
+- **Card hover lift** (`hover:-translate-y-0.5` + hover shadow) — useless on touch devices
+- **Font weight bump** (`font-extrabold` → `font-bold`) — extrabold is heavier than needed
+
+### Needs page — keep left accents, soften
+- **NeedsSummaryCards**: Keep color-coded left borders (red=active, yellow=transit, green=fulfilled, red=critical) but reduce from 3px to 2px
+- **NeedsCoordinationMap**: Revert to subtle border — map pins already carry status colors
+
+### Relief Operations page — revert borders
+- **SummaryCards**: Revert to `border border-neutral-400/20`
+- **DonationsByOrg**: Revert to `border border-neutral-400/20`
+- **DeploymentHubs**: Revert to `border border-neutral-400/20`
+- **GoodsByCategory**: Revert to `border border-neutral-400/20`
+- **AidDistributionMap**: Revert to `border border-neutral-400/20`
+
+### Submit Form — revert borders
+- **SubmitForm container** (in SubmitPage.tsx): Revert to subtle border — yellow accent reads as warning state
+
+### Keep as-is
+- Nunito font
+- Teal color palette
+- Header shadow (replaces old border-bottom)
+- Report button glow
+- Pinging status dot in footer
+- `rounded-2xl` card corners
+- Form input padding (`px-4 py-3`) and `rounded-xl` inputs
+- Card box shadows (non-hover)
+
+## Files to modify
+1. `src/index.css` — remove grain texture, animation keyframes, animation class
+2. `src/components/NeedsSummaryCards.tsx` — soften border to 2px, remove animation/hover classes
+3. `src/components/NeedsCoordinationMap.tsx` — revert to subtle border
+4. `src/components/SummaryCards.tsx` — revert border, remove animation/hover
+5. `src/components/DonationsByOrg.tsx` — revert border
+6. `src/components/DeploymentHubs.tsx` — revert border, revert extrabold
+7. `src/components/GoodsByCategory.tsx` — revert border, revert extrabold
+8. `src/components/AidDistributionMap.tsx` — revert border
+9. `src/components/SubmitForm.tsx` — revert border on container (via SubmitPage.tsx if needed)

--- a/src/components/AidDistributionMap.tsx
+++ b/src/components/AidDistributionMap.tsx
@@ -25,7 +25,7 @@ export default function AidDistributionMap({
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-2xl border-l-[3px] border-success bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+    <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-neutral-50">
           {t("Dashboard.aidDistributionMap")}

--- a/src/components/DeploymentHubs.tsx
+++ b/src/components/DeploymentHubs.tsx
@@ -8,7 +8,7 @@ export default function DeploymentHubs({ hubs }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+    <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.deploymentHubs")}
       </h3>
@@ -23,7 +23,7 @@ export default function DeploymentHubs({ hubs }: Props) {
               <p className="text-sm text-neutral-400">{hub.municipality}</p>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-extrabold text-neutral-50">{hub.count}</p>
+              <p className="text-2xl font-bold text-neutral-50">{hub.count}</p>
               <p className="text-xs text-neutral-400/60">{t("Dashboard.deployments")}</p>
             </div>
           </div>

--- a/src/components/DonationsByOrg.tsx
+++ b/src/components/DonationsByOrg.tsx
@@ -20,7 +20,7 @@ export default function DonationsByOrg({ donations }: Props) {
   const total = donations.reduce((sum, d) => sum + d.amount, 0);
 
   return (
-    <div className="rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+    <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.donationsByOrg")}
       </h3>

--- a/src/components/GoodsByCategory.tsx
+++ b/src/components/GoodsByCategory.tsx
@@ -23,7 +23,7 @@ export default function GoodsByCategory({ categories }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="rounded-2xl border-l-[3px] border-accent bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+    <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <h3 className="mb-4 text-lg font-semibold text-neutral-50">
         {t("Dashboard.goodsPurchased")}
       </h3>
@@ -37,7 +37,7 @@ export default function GoodsByCategory({ categories }: Props) {
               {CATEGORY_ICONS[cat.name] || "📋"}
             </p>
             <p className="mt-1 text-sm text-neutral-400">{cat.name}</p>
-            <p className="mt-1 text-lg font-extrabold text-primary">
+            <p className="mt-1 text-lg font-bold text-primary">
               {cat.total.toLocaleString()}
             </p>
           </div>

--- a/src/components/NeedsCoordinationMap.tsx
+++ b/src/components/NeedsCoordinationMap.tsx
@@ -36,7 +36,7 @@ export default function NeedsCoordinationMap({ needsPoints }: Props) {
       : needsPoints.filter((p) => p.accessStatus === accessFilter);
 
   return (
-    <div className="rounded-2xl border-l-[3px] border-error bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+    <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-neutral-50">
           {t("Dashboard.needsMap")}

--- a/src/components/NeedsSummaryCards.tsx
+++ b/src/components/NeedsSummaryCards.tsx
@@ -18,11 +18,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
       {/* Active Needs */}
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-error bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "0ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border-l-2 border-primary bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.activeNeeds")}
         </p>
-        <p className="mt-2 text-3xl font-extrabold text-error">
+        <p className="mt-2 text-3xl font-bold text-primary">
           {summary.byStatus.verified}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -31,11 +31,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* In Transit */}
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-warning bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "60ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border-l-2 border-warning bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.inTransit")}
         </p>
-        <p className="mt-2 text-3xl font-extrabold text-warning">
+        <p className="mt-2 text-3xl font-bold text-warning">
           {summary.byStatus.in_transit}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -44,11 +44,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* Fulfilled */}
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-success bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "120ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border-l-2 border-success bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.fulfilled")}
         </p>
-        <p className="mt-2 text-3xl font-extrabold text-success">
+        <p className="mt-2 text-3xl font-bold text-success">
           {summary.byStatus.completed}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -57,11 +57,11 @@ export default function NeedsSummaryCards({ summary }: Props) {
       </div>
 
       {/* Critical */}
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-error bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "180ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border-l-2 border-error bg-secondary p-5 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.criticalNeeds")}
         </p>
-        <p className="mt-2 text-3xl font-extrabold text-error">
+        <p className="mt-2 text-3xl font-bold text-error">
           {summary.critical}
         </p>
         <p className="mt-1 text-xs text-neutral-400">

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -35,14 +35,14 @@ export default function SummaryCards({
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-success bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "0ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <div className="flex items-center justify-between">
           <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
             {t("Dashboard.totalDonations")}
           </p>
           <TrendIcon />
         </div>
-        <p className="mt-2 text-3xl font-extrabold text-success">
+        <p className="mt-2 text-3xl font-bold text-success">
           ₱{totalDonations.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -50,14 +50,14 @@ export default function SummaryCards({
         </p>
       </div>
 
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "60ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <div className="flex items-center justify-between">
           <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
             {t("Dashboard.totalBeneficiaries")}
           </p>
           <TrendIcon />
         </div>
-        <p className="mt-2 text-3xl font-extrabold text-neutral-50">
+        <p className="mt-2 text-3xl font-bold text-neutral-50">
           {totalBeneficiaries.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">
@@ -65,11 +65,11 @@ export default function SummaryCards({
         </p>
       </div>
 
-      <div className="animate-fade-slide-up rounded-2xl border-l-[3px] border-primary bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_2px_6px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.2)]" style={{ "--delay": "120ms" } as React.CSSProperties}>
+      <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
         <p className="text-xs font-medium uppercase tracking-wider text-neutral-400">
           {t("Dashboard.volunteerCount")}
         </p>
-        <p className="mt-2 text-3xl font-extrabold text-neutral-50">
+        <p className="mt-2 text-3xl font-bold text-neutral-50">
           {volunteerCount.toLocaleString()}
         </p>
         <p className="mt-1 text-xs text-neutral-400">

--- a/src/index.css
+++ b/src/index.css
@@ -15,40 +15,14 @@
   --color-base: #1a1d21;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   background: var(--color-base);
   color: var(--color-neutral-50);
   font-family: "Nunito Variable", Nunito, Arial, sans-serif;
-}
-
-/* Faint grain texture — registers as "surface" vs "void" */
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  pointer-events: none;
-  opacity: 0.03;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.7' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-repeat: repeat;
-  background-size: 256px 256px;
-}
-
-/* Staggered card entrance animation */
-@keyframes fadeSlideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-fade-slide-up {
-  animation: fadeSlideUp 400ms ease-out both;
-  animation-delay: var(--delay, 0ms);
 }
 
 .leaflet-popup-content-wrapper {

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -12,7 +12,7 @@ export function SubmitPage() {
         <h1 className="mb-6 text-center text-2xl font-bold text-neutral-50">
           {t("SubmitForm.title")}
         </h1>
-        <div className="rounded-2xl border-l-[3px] border-accent bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
+        <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 shadow-[0_1px_3px_rgba(0,0,0,0.3),0_4px_12px_rgba(0,0,0,0.15)]">
           <SubmitForm />
         </div>
       </main>


### PR DESCRIPTION
## Summary
- Removed grain texture overlay, card entrance animations (`fadeSlideUp`), and hover lift effects — unnecessary on touch devices and add GPU/CSS overhead
- Reverted colored left-accent borders to subtle `border border-neutral-400/20` on Relief Ops cards, map sections, and submit form — kept status-coded `border-l-2` only on Needs summary cards where color encodes meaning (teal=active, yellow=transit, green=fulfilled, red=critical)
- Changed Active Needs card from red to teal (`primary`) to differentiate from Critical
- Added `scrollbar-gutter: stable` to prevent layout shift when navigating between pages of different lengths
- Updated design system rule to document the two card border strategies

## Test plan
- [x] `npm test` — 70/70 passing
- [x] `npm run build` — clean TypeScript + production build
- [x] Visual check: Needs page cards have subtle colored left accents
- [x] Visual check: Relief Ops + Submit form cards have uniform subtle borders
- [x] Visual check: No layout shift when switching between Needs/Relief Ops/Stories
- [x] Visual check: No entrance animations or hover lift on any cards