### PR TITLE
fix: auto-reload on stale chunk errors after PWA deploys

### DIFF
--- a/src/components/AidDistributionMap.tsx
+++ b/src/components/AidDistributionMap.tsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy } from "react";
+import { Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import MapSkeleton from "@/components/maps/MapSkeleton";
+import { lazyWithReload } from "@/lib/lazy-reload";
 
-const DeploymentMap = lazy(() => import("@/components/maps/DeploymentMap"));
+const DeploymentMap = lazyWithReload(() => import("@/components/maps/DeploymentMap"));
 
 type DeploymentPoint = {
   lat: number;

--- a/src/components/NeedsCoordinationMap.tsx
+++ b/src/components/NeedsCoordinationMap.tsx
@@ -1,9 +1,10 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, useState } from "react";
 import { useTranslation } from "react-i18next";
 import MapSkeleton from "@/components/maps/MapSkeleton";
+import { lazyWithReload } from "@/lib/lazy-reload";
 import type { NeedPoint } from "@/lib/queries";
 
-const NeedsMap = lazy(() => import("@/components/maps/NeedsMap"));
+const NeedsMap = lazyWithReload(() => import("@/components/maps/NeedsMap"));
 
 type Props = {
   needsPoints: NeedPoint[];

--- a/src/lib/lazy-reload.ts
+++ b/src/lib/lazy-reload.ts
@@ -1,0 +1,22 @@
+import { lazy } from "react";
+
+/**
+ * Wraps a dynamic import with a single page-reload retry.
+ * Fixes stale-chunk errors after PWA deploys where the old service worker
+ * serves cached HTML referencing chunk hashes that no longer exist.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function lazyWithReload(
+  importFn: () => Promise<{ default: React.ComponentType<any> }>,
+) {
+  return lazy(() =>
+    importFn().catch(() => {
+      const key = "chunk-reload";
+      if (!sessionStorage.getItem(key)) {
+        sessionStorage.setItem(key, "1");
+        window.location.reload();
+      }
+      return new Promise<never>(() => {});
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- Wraps lazy-loaded map imports (DeploymentMap, NeedsMap) with a catch handler that triggers a single page reload when a chunk fails to load
- Prevents users from seeing "Unexpected Application Error" screens after new deployments when the old service worker serves stale HTML with outdated chunk hashes
- Uses `sessionStorage` flag to prevent infinite reload loops

## Test plan
- [x] Deploy to kapwahelp.org and verify Relief and Needs pages load normally
- [x] Verify `npm run build` produces correct lazy chunks
- [x] All 73 unit tests pass