### PR TITLE
feat: add geohash column and client-side encoding

### DIFF
--- a/src/components/SubmitForm.tsx
+++ b/src/components/SubmitForm.tsx
@@ -13,6 +13,7 @@ import {
   getOutboxEntries,
   removeFromOutbox,
 } from "@/lib/form-cache";
+import { encodeGeohash } from "@/lib/geohash";
 import { useOutbox } from "@/lib/outbox-context";
 
 interface Barangay {
@@ -177,6 +178,7 @@ export default function SubmitForm() {
       notes: (formData.get("notes") as string) || null,
       lat: coords?.lat ?? null,
       lng: coords?.lng ?? null,
+      geohash: coords ? encodeGeohash(coords.lat, coords.lng) : null,
     };
 
     try {

--- a/src/lib/geohash.ts
+++ b/src/lib/geohash.ts
@@ -1,0 +1,50 @@
+/**
+ * Encode latitude/longitude into a geohash string.
+ *
+ * Precision 6 ≈ 1.2km × 600m cells — roughly barangay-sized,
+ * suitable for proximity grouping in La Union.
+ *
+ * Reference: docs/scope.md §4 (Needs Dataset), §5.C (Conflict Detection)
+ */
+
+const BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+export function encodeGeohash(
+  lat: number,
+  lng: number,
+  precision = 6,
+): string {
+  let minLat = -90,
+    maxLat = 90;
+  let minLng = -180,
+    maxLng = 180;
+  let hash = "";
+  let bit = 0;
+  let ch = 0;
+  let isLng = true;
+
+  while (hash.length < precision) {
+    const mid = isLng ? (minLng + maxLng) / 2 : (minLat + maxLat) / 2;
+    const val = isLng ? lng : lat;
+
+    if (val >= mid) {
+      ch |= 1 << (4 - bit);
+      if (isLng) minLng = mid;
+      else minLat = mid;
+    } else {
+      if (isLng) maxLng = mid;
+      else maxLat = mid;
+    }
+
+    isLng = !isLng;
+    bit++;
+
+    if (bit === 5) {
+      hash += BASE32[ch];
+      bit = 0;
+      ch = 0;
+    }
+  }
+
+  return hash;
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -193,6 +193,7 @@ export interface SubmissionInsert {
   urgency: string;
   lat: number | null;
   lng: number | null;
+  geohash?: string | null;
   submission_photo_url?: string | null;
   dispatch_photo_url?: string | null;
   delivery_photo_url?: string | null;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS submissions (
   gap_category    text NOT NULL CHECK (gap_category IN ('lunas', 'sustenance', 'shelter')),
   lat             decimal(9,6),
   lng             decimal(9,6),
+  geohash         text,
   -- Access / passability (scope §5.A)
   access_status   text NOT NULL CHECK (access_status IN ('truck', '4x4', 'boat', 'foot_only', 'cut_off')),
   -- Need details


### PR DESCRIPTION
## Summary

- Adds nullable `geohash` column to `submissions` table in schema
- Adds zero-dependency geohash encoder (`src/lib/geohash.ts`, precision 6 ≈ 1.2km × 600m cells)
- Computes geohash on submit when GPS coordinates are available
- Existing data unaffected (column is nullable, seed data unchanged)

Phase 1 groundwork for #72 (geohash-based conflict detection per scope §5.C).

## Test plan

- [x] `npm run build` passes (TypeScript + production build)
- [x] `npm test` — all 90 unit tests pass
- [x] `npm run verify` — smoke tests pass
- [x] Submit a need with GPS enabled → verify `geohash` is populated in Supabase
- [x] Submit a need without GPS → verify `geohash` is null