### PR TITLE
feat: generalize offline outbox for all creation forms

### DIFF
--- a/.claude/rules/offline.md
+++ b/.claude/rules/offline.md
@@ -3,6 +3,7 @@ paths:
   - "src/lib/cache.ts"
   - "src/lib/form-cache.ts"
   - "src/lib/outbox-context.tsx"
+  - "src/lib/eager-cache.ts"
   - "vite.config.ts"
   - "src/components/maps/**"
 ---
@@ -24,9 +25,15 @@ Stale-while-revalidate with IndexedDB (DB version 6):
 
 OSM tiles use Workbox CacheFirst strategy (cache name: `map-tiles`, max 200 tiles, 30-day expiry). `ReliefMapLeaflet` shows fallback overlay after 3 consecutive `tileerror` events; clears when tiles load again.
 
-## Offline Submit Form (`src/lib/form-cache.ts` + `src/lib/outbox-context.tsx`)
+## Eager Reference Data Cache (`src/lib/eager-cache.ts`)
 
-- Form dropdown options (aid categories) cached in IndexedDB
-- Needs go into IndexedDB outbox queue with client-generated UUIDs (idempotent sync)
-- Outbox flush handles junction table inserts (need → need_categories)
-- `OutboxProvider` context manages queue and auto-syncs on `online` event
+`useEagerCache()` runs at app mount (in `RootLayout`) — pre-fetches activeEvent, organizations, and aidCategories into IndexedDB so forms work offline. Re-fetches on `online` event.
+
+## Offline Form Outbox (`src/lib/form-cache.ts` + `src/lib/outbox-context.tsx`)
+
+- All four creation forms (need, donation, purchase, hazard) support offline submission
+- Discriminated union outbox in IndexedDB — entries typed by `{ type: "need" | "donation" | "purchase" | "hazard" }`
+- Client-generated UUIDs on all forms for idempotent sync (duplicate 23505 errors silently removed)
+- Hazard entries store compressed photo Blobs; uploaded to Supabase Storage during flush
+- Form dropdown data (aid categories, organizations, active event) cached in IndexedDB with cache-first loading
+- `OutboxProvider` dispatches flush by entry type and auto-syncs on `online` event

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -160,6 +160,8 @@
     "submit": "Report Hazard",
     "submitting": "Submitting...",
     "success": "Hazard reported successfully!",
+    "savedTitle": "Hazard saved!",
+    "savedMessage": "Will send when you're back online. Photo will be uploaded when connected.",
     "error": "Failed to report hazard"
   },
   "Transparency": {
@@ -188,6 +190,9 @@
     "notes": "Notes (optional)",
     "submit": "Report Donation",
     "success": "Donation reported successfully!",
+    "successMessage": "Thank you. Your donation has been recorded.",
+    "savedTitle": "Donation saved!",
+    "savedMessage": "Will send when you're back online.",
     "error": "Failed to report donation",
     "donorName": "Donor Name",
     "donorNamePlaceholder": "Optional — name of donor",
@@ -204,6 +209,9 @@
     "notes": "Notes (optional)",
     "submit": "Report Purchase",
     "success": "Purchase reported successfully!",
+    "successMessage": "Thank you. Your purchase has been recorded.",
+    "savedTitle": "Purchase saved!",
+    "savedMessage": "Will send when you're back online.",
     "error": "Failed to report purchase"
   },
   "Stories": {

--- a/public/locales/fil/translation.json
+++ b/public/locales/fil/translation.json
@@ -160,6 +160,8 @@
     "submit": "Iulat ang Hazard",
     "submitting": "Submitting...",
     "success": "Matagumpay na naiulat ang Hazard!",
+    "savedTitle": "Naligtas si Hazard!",
+    "savedMessage": "Ipapadala kapag online ka na ulit. Ang larawan ay ia-upload kapag nakakonekta.",
     "error": "Nabigong mag-ulat ng panganib"
   },
   "Transparency": {
@@ -188,6 +190,9 @@
     "notes": "Mga Tala (opsyonal)",
     "submit": "Iulat ang Donasyon",
     "success": "Matagumpay na naiulat ang donasyon!",
+    "successMessage": "salamat po. Ang iyong donasyon ay naitala.",
+    "savedTitle": "Nai-save ang donasyon!",
+    "savedMessage": "Ipapadala kapag online ka na ulit.",
     "error": "Nabigong mag-ulat ng donasyon",
     "donorName": "Pangalan ng Donor",
     "donorNamePlaceholder": "Opsyonal — pangalan ng donor",
@@ -204,6 +209,9 @@
     "notes": "Mga Tala (opsyonal)",
     "submit": "Iulat ang Pagbili",
     "success": "Matagumpay na naiulat ang pagbili!",
+    "successMessage": "salamat po. Ang iyong pagbili ay naitala.",
+    "savedTitle": "Naka-save ang pagbili!",
+    "savedMessage": "Ipapadala kapag online ka na ulit.",
     "error": "Nabigong iulat ang pagbili"
   },
   "Stories": {

--- a/public/locales/ilo/translation.json
+++ b/public/locales/ilo/translation.json
@@ -160,6 +160,8 @@
     "submit": "Ireport ti Peligro",
     "submitting": "Submitting...",
     "success": "Naballigi ti impadamag ti Hazard!",
+    "savedTitle": "Naisalakan ti peggad!",
+    "savedMessage": "Ipatulodna inton agsublika nga online. Mai-upload ti retrato no maikonekta.",
     "error": "Napaay a nangipadamag iti peggad"
   },
   "Transparency": {
@@ -188,6 +190,9 @@
     "notes": "Dagiti Pakaammo (opsional)",
     "submit": "Ireport ti Donasion",
     "success": "Naballigi ti naipadamag a donasion!",
+    "successMessage": "Aagyaman. Nairekord ti donasionyo.",
+    "savedTitle": "Naisalakan ti donasion!",
+    "savedMessage": "Ipatulodna inton agsublika nga online.",
     "error": "Napaay a nangipadamag iti donasion",
     "donorName": "Nagan ti Donor",
     "donorNamePlaceholder": "Opsional — nagan ti donor",
@@ -204,6 +209,9 @@
     "notes": "Dagiti Pakaammo (opsional)",
     "submit": "Report ti Panaggatang",
     "success": "Naballigi ti naipadamag a panaggatang!",
+    "successMessage": "Aagyaman. Nairekord ti ginatangmo.",
+    "savedTitle": "Nasalbar ti panaggatang!",
+    "savedMessage": "Ipatulodna inton agsublika nga online.",
     "error": "Napaay a nangipadamag iti panaggatang"
   },
   "Stories": {

--- a/src/components/DonationForm.tsx
+++ b/src/components/DonationForm.tsx
@@ -5,7 +5,10 @@ import {
   getAidCategories,
   getActiveEvent,
   insertDonation,
+  type DonationInsert,
 } from "@/lib/queries";
+import { getCachedOptions, setCachedOptions, addToOutbox } from "@/lib/form-cache";
+import { useOutbox } from "@/lib/outbox-context";
 
 interface Organization {
   id: string;
@@ -20,26 +23,51 @@ interface AidCategory {
 
 export default function DonationForm() {
   const { t } = useTranslation();
+  const { refreshCount } = useOutbox();
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [categories, setCategories] = useState<AidCategory[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [donationType, setDonationType] = useState<"cash" | "in_kind">("cash");
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [savedOffline, setSavedOffline] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formKey, setFormKey] = useState(0);
   const [eventId, setEventId] = useState<string | null>(null);
 
   useEffect(() => {
-    getActiveEvent().then((event) => {
-      if (event) {
+    let cancelled = false;
+
+    // Load active event (cache-first)
+    getCachedOptions<{ id: string; name: string }>("activeEvent").then((cachedE) => {
+      if (cancelled) return;
+      if (cachedE?.data.length) setEventId(cachedE.data[0].id);
+
+      getActiveEvent().then((event) => {
+        if (cancelled || !event) return;
         setEventId(event.id);
-        getOrganizations(event.id).then(setOrgs).catch(() => {});
-      }
+
+        // Load orgs (cache-first, needs eventId)
+        getCachedOptions<Organization>("organizations").then((cachedO) => {
+          if (cancelled) return;
+          if (cachedO?.data.length) setOrgs(cachedO.data);
+          getOrganizations(event.id)
+            .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
+            .catch(() => {});
+        });
+      }).catch(() => {});
     });
-    getAidCategories()
-      .then(setCategories)
-      .catch(() => {});
+
+    // Load categories (cache-first)
+    getCachedOptions<AidCategory>("aidCategories").then((cachedC) => {
+      if (cancelled) return;
+      if (cachedC?.data.length) setCategories(cachedC.data);
+      getAidCategories()
+        .then((freshC) => { if (!cancelled) { setCategories(freshC); setCachedOptions("aidCategories", freshC); } })
+        .catch(() => {});
+    });
+
+    return () => { cancelled = true; };
   }, []);
 
   function toggleCategory(id: string) {
@@ -64,7 +92,9 @@ export default function DonationForm() {
         setSubmitting(false);
         return;
       }
-      await insertDonation({
+      const id = crypto.randomUUID();
+      const payload: DonationInsert = {
+        id,
         event_id: eventId,
         organization_id: formData.get("organization_id") as string,
         donor_name: (formData.get("donor_name") as string) || undefined,
@@ -74,8 +104,21 @@ export default function DonationForm() {
         date: (formData.get("date") as string) || new Date().toISOString().split("T")[0],
         notes: (formData.get("notes") as string) || undefined,
         category_ids: donationType === "in_kind" ? Array.from(selectedCategories) : undefined,
-      });
-      setSubmitted(true);
+      };
+
+      try {
+        await insertDonation(payload);
+        setSubmitted(true);
+      } catch {
+        try {
+          await addToOutbox({ type: "donation", payload });
+          refreshCount();
+          setSavedOffline(true);
+          setSubmitted(true);
+        } catch {
+          setError(t("DonationForm.error"));
+        }
+      }
     } catch {
       setError(t("DonationForm.error"));
     } finally {
@@ -86,10 +129,16 @@ export default function DonationForm() {
   if (submitted) {
     return (
       <div className="text-center py-8">
-        <h2 className="text-xl font-bold text-success">{t("DonationForm.success")}</h2>
+        <h2 className={`text-xl font-bold ${savedOffline ? "text-warning" : "text-success"}`}>
+          {t(savedOffline ? "DonationForm.savedTitle" : "DonationForm.success")}
+        </h2>
+        <p className="mt-2 text-neutral-400">
+          {t(savedOffline ? "DonationForm.savedMessage" : "DonationForm.successMessage")}
+        </p>
         <button
           onClick={() => {
             setSubmitted(false);
+            setSavedOffline(false);
             setDonationType("cash");
             setSelectedCategories(new Set());
             setFormKey((k) => k + 1);

--- a/src/components/DonationForm.tsx
+++ b/src/components/DonationForm.tsx
@@ -47,15 +47,17 @@ export default function DonationForm() {
         if (cancelled || !event) return;
         setEventId(event.id);
 
-        // Load orgs (cache-first, needs eventId)
-        getCachedOptions<Organization>("organizations").then((cachedO) => {
-          if (cancelled) return;
-          if (cachedO?.data.length) setOrgs(cachedO.data);
-          getOrganizations(event.id)
-            .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
-            .catch(() => {});
-        });
+        // Refresh orgs from network
+        getOrganizations(event.id)
+          .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
+          .catch(() => {});
       }).catch(() => {});
+    });
+
+    // Load orgs (cache-first, independent of network)
+    getCachedOptions<Organization>("organizations").then((cachedO) => {
+      if (cancelled) return;
+      if (cachedO?.data.length) setOrgs(cachedO.data);
     });
 
     // Load categories (cache-first)

--- a/src/components/HazardForm.tsx
+++ b/src/components/HazardForm.tsx
@@ -1,8 +1,10 @@
 import { useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { getActiveEvent, insertHazard } from "@/lib/queries";
+import { getActiveEvent, insertHazard, type HazardInsert } from "@/lib/queries";
 import { compressPhoto, uploadPhoto } from "@/lib/photo";
 import { roundCoord } from "@/lib/geohash";
+import { getCachedOptions, addToOutbox } from "@/lib/form-cache";
+import { useOutbox } from "@/lib/outbox-context";
 
 interface HazardFormProps {
   coords: { lat: number; lng: number } | null;
@@ -10,6 +12,7 @@ interface HazardFormProps {
 
 export default function HazardForm({ coords }: HazardFormProps) {
   const { t } = useTranslation();
+  const { refreshCount } = useOutbox();
   const [description, setDescription] = useState("");
   const [reportedBy, setReportedBy] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
@@ -17,13 +20,18 @@ export default function HazardForm({ coords }: HazardFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [savedOffline, setSavedOffline] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [eventId, setEventId] = useState<string | null>(null);
 
   useEffect(() => {
-    getActiveEvent()
-      .then((event) => { if (event) setEventId(event.id); })
-      .catch(() => {});
+    getCachedOptions<{ id: string; name: string }>("activeEvent").then((cachedE) => {
+      if (cachedE?.data.length) setEventId(cachedE.data[0].id);
+
+      getActiveEvent()
+        .then((event) => { if (event) setEventId(event.id); })
+        .catch(() => {});
+    });
   }, []);
 
   function handlePhotoChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -53,22 +61,42 @@ export default function HazardForm({ coords }: HazardFormProps) {
         return;
       }
 
-      let photoUrl: string | undefined;
+      const id = crypto.randomUUID();
+
+      // Compress photo if present (works offline — pure browser APIs)
+      let compressedPhoto: Blob | undefined;
       if (photo) {
-        const compressed = await compressPhoto(photo);
-        const hazardId = crypto.randomUUID();
-        photoUrl = (await uploadPhoto("photos", `hazards/${hazardId}.jpg`, compressed)) ?? undefined;
+        compressedPhoto = await compressPhoto(photo);
       }
 
-      await insertHazard({
+      const payload: HazardInsert = {
+        id,
         event_id: eventId,
         description,
-        photo_url: photoUrl,
         latitude: roundCoord(coords.lat),
         longitude: roundCoord(coords.lng),
         reported_by: reportedBy || undefined,
-      });
-      setSubmitted(true);
+      };
+
+      try {
+        // Online path: upload photo then insert
+        if (compressedPhoto) {
+          const photoUrl = (await uploadPhoto("photos", `hazards/${id}.jpg`, compressedPhoto)) ?? undefined;
+          payload.photo_url = photoUrl;
+        }
+        await insertHazard(payload);
+        setSubmitted(true);
+      } catch {
+        try {
+          // Offline path: store payload + photo blob in outbox
+          await addToOutbox({ type: "hazard", payload, photo: compressedPhoto });
+          refreshCount();
+          setSavedOffline(true);
+          setSubmitted(true);
+        } catch {
+          setError(t("HazardForm.error"));
+        }
+      }
     } catch {
       setError(t("HazardForm.error"));
     } finally {
@@ -79,12 +107,18 @@ export default function HazardForm({ coords }: HazardFormProps) {
   if (submitted) {
     return (
       <div className="rounded-2xl border border-neutral-400/20 bg-secondary p-6 text-center">
-        <p className="mb-4 text-lg font-semibold text-success">
-          {t("HazardForm.success")}
+        <p className={`mb-4 text-lg font-semibold ${savedOffline ? "text-warning" : "text-success"}`}>
+          {t(savedOffline ? "HazardForm.savedTitle" : "HazardForm.success")}
         </p>
+        {savedOffline && (
+          <p className="mb-4 text-sm text-neutral-400">
+            {t("HazardForm.savedMessage")}
+          </p>
+        )}
         <button
           onClick={() => {
             setSubmitted(false);
+            setSavedOffline(false);
             setDescription("");
             setReportedBy("");
             removePhoto();

--- a/src/components/PurchaseForm.tsx
+++ b/src/components/PurchaseForm.tsx
@@ -46,15 +46,17 @@ export default function PurchaseForm() {
         if (cancelled || !event) return;
         setEventId(event.id);
 
-        // Load orgs (cache-first, needs eventId)
-        getCachedOptions<Organization>("organizations").then((cachedO) => {
-          if (cancelled) return;
-          if (cachedO?.data.length) setOrgs(cachedO.data);
-          getOrganizations(event.id)
-            .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
-            .catch(() => {});
-        });
+        // Refresh orgs from network
+        getOrganizations(event.id)
+          .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
+          .catch(() => {});
       }).catch(() => {});
+    });
+
+    // Load orgs (cache-first, independent of network)
+    getCachedOptions<Organization>("organizations").then((cachedO) => {
+      if (cancelled) return;
+      if (cachedO?.data.length) setOrgs(cachedO.data);
     });
 
     // Load categories (cache-first)

--- a/src/components/PurchaseForm.tsx
+++ b/src/components/PurchaseForm.tsx
@@ -5,7 +5,10 @@ import {
   getAidCategories,
   getActiveEvent,
   insertPurchase,
+  type PurchaseInsert,
 } from "@/lib/queries";
+import { getCachedOptions, setCachedOptions, addToOutbox } from "@/lib/form-cache";
+import { useOutbox } from "@/lib/outbox-context";
 
 interface Organization {
   id: string;
@@ -20,23 +23,50 @@ interface AidCategory {
 
 export default function PurchaseForm() {
   const { t } = useTranslation();
+  const { refreshCount } = useOutbox();
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [categories, setCategories] = useState<AidCategory[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [savedOffline, setSavedOffline] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formKey, setFormKey] = useState(0);
   const [eventId, setEventId] = useState<string | null>(null);
 
   useEffect(() => {
-    getActiveEvent().then((event) => {
-      if (event) {
+    let cancelled = false;
+
+    // Load active event (cache-first)
+    getCachedOptions<{ id: string; name: string }>("activeEvent").then((cachedE) => {
+      if (cancelled) return;
+      if (cachedE?.data.length) setEventId(cachedE.data[0].id);
+
+      getActiveEvent().then((event) => {
+        if (cancelled || !event) return;
         setEventId(event.id);
-        getOrganizations(event.id).then(setOrgs).catch(() => {});
-      }
+
+        // Load orgs (cache-first, needs eventId)
+        getCachedOptions<Organization>("organizations").then((cachedO) => {
+          if (cancelled) return;
+          if (cachedO?.data.length) setOrgs(cachedO.data);
+          getOrganizations(event.id)
+            .then((freshO) => { if (!cancelled) { setOrgs(freshO); setCachedOptions("organizations", freshO); } })
+            .catch(() => {});
+        });
+      }).catch(() => {});
     });
-    getAidCategories().then(setCategories).catch(() => {});
+
+    // Load categories (cache-first)
+    getCachedOptions<AidCategory>("aidCategories").then((cachedC) => {
+      if (cancelled) return;
+      if (cachedC?.data.length) setCategories(cachedC.data);
+      getAidCategories()
+        .then((freshC) => { if (!cancelled) { setCategories(freshC); setCachedOptions("aidCategories", freshC); } })
+        .catch(() => {});
+    });
+
+    return () => { cancelled = true; };
   }, []);
 
   function toggleCategory(id: string) {
@@ -62,15 +92,30 @@ export default function PurchaseForm() {
         setSubmitting(false);
         return;
       }
-      await insertPurchase({
+      const id = crypto.randomUUID();
+      const payload: PurchaseInsert = {
+        id,
         event_id: eventId,
         organization_id: formData.get("organization_id") as string,
         cost: Number(formData.get("cost")),
         date: (formData.get("date") as string) || new Date().toISOString().split("T")[0],
         notes: (formData.get("notes") as string) || undefined,
         category_ids: Array.from(selectedCategories),
-      });
-      setSubmitted(true);
+      };
+
+      try {
+        await insertPurchase(payload);
+        setSubmitted(true);
+      } catch {
+        try {
+          await addToOutbox({ type: "purchase", payload });
+          refreshCount();
+          setSavedOffline(true);
+          setSubmitted(true);
+        } catch {
+          setError(t("PurchaseForm.error"));
+        }
+      }
     } catch {
       setError(t("PurchaseForm.error"));
     } finally {
@@ -81,10 +126,16 @@ export default function PurchaseForm() {
   if (submitted) {
     return (
       <div className="text-center py-8">
-        <h2 className="text-xl font-bold text-success">{t("PurchaseForm.success")}</h2>
+        <h2 className={`text-xl font-bold ${savedOffline ? "text-warning" : "text-success"}`}>
+          {t(savedOffline ? "PurchaseForm.savedTitle" : "PurchaseForm.success")}
+        </h2>
+        <p className="mt-2 text-neutral-400">
+          {t(savedOffline ? "PurchaseForm.savedMessage" : "PurchaseForm.successMessage")}
+        </p>
         <button
           onClick={() => {
             setSubmitted(false);
+            setSavedOffline(false);
             setSelectedCategories(new Set());
             setFormKey((k) => k + 1);
           }}

--- a/src/components/RootLayout.tsx
+++ b/src/components/RootLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useParams, Navigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { supportedLocales, type Locale } from "../i18n";
 import { OutboxProvider } from "@/lib/outbox-context";
+import { useEagerCache } from "@/lib/eager-cache";
 
 export function RootLayout() {
   const { locale } = useParams<{ locale: string }>();
@@ -21,6 +22,8 @@ export function RootLayout() {
       document.documentElement.lang = locale!;
     }
   }, [locale, isValid]);
+
+  useEagerCache();
 
   if (!isValid) {
     return <Navigate to="/en" replace />;

--- a/src/components/SubmitForm.tsx
+++ b/src/components/SubmitForm.tsx
@@ -40,12 +40,19 @@ export default function SubmitForm({ coords }: SubmitFormProps) {
   useEffect(() => {
     let cancelled = false;
 
-    // Load active event
-    getActiveEvent()
-      .then((event) => {
-        if (!cancelled && event) setEventId(event.id);
-      })
-      .catch(() => {});
+    // Load active event (cache-first)
+    getCachedOptions<{ id: string; name: string }>("activeEvent").then((cachedE) => {
+      if (cancelled) return;
+      if (cachedE?.data.length) {
+        setEventId(cachedE.data[0].id);
+      }
+
+      getActiveEvent()
+        .then((event) => {
+          if (!cancelled && event) setEventId(event.id);
+        })
+        .catch(() => {});
+    });
 
     // Load aid categories (cache-first)
     getCachedOptions<AidCategory>("aidCategories").then((cachedC) => {
@@ -119,7 +126,7 @@ export default function SubmitForm({ coords }: SubmitFormProps) {
         setSubmitted(true);
       } catch {
         try {
-          await addToOutbox(payload);
+          await addToOutbox({ type: "need", payload });
           refreshCount();
           setSavedOffline(true);
           setSubmitted(true);

--- a/src/lib/eager-cache.ts
+++ b/src/lib/eager-cache.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { getActiveEvent, getAidCategories, getOrganizations } from "@/lib/queries";
+import { setCachedOptions } from "@/lib/form-cache";
+
+function cacheReferenceData() {
+  getActiveEvent()
+    .then((event) => {
+      if (!event) return;
+      setCachedOptions("activeEvent", [event]);
+      getOrganizations(event.id)
+        .then((orgs) => setCachedOptions("organizations", orgs))
+        .catch(() => {});
+    })
+    .catch(() => {});
+
+  getAidCategories()
+    .then((cats) => setCachedOptions("aidCategories", cats))
+    .catch(() => {});
+}
+
+export function useEagerCache() {
+  useEffect(() => {
+    if (navigator.onLine) cacheReferenceData();
+
+    window.addEventListener("online", cacheReferenceData);
+    return () => window.removeEventListener("online", cacheReferenceData);
+  }, []);
+}

--- a/src/lib/form-cache.ts
+++ b/src/lib/form-cache.ts
@@ -79,7 +79,9 @@ export async function setCachedOptions<T>(
 
 // --- Outbox ---
 
-export async function addToOutbox(entry: Omit<OutboxEntry, "createdAt">): Promise<void> {
+type OutboxInput = OutboxEntry extends infer T ? T extends OutboxEntry ? Omit<T, "createdAt"> : never : never;
+
+export async function addToOutbox(entry: OutboxInput): Promise<void> {
   let db: IDBDatabase | null = null;
   try {
     db = await openDB();

--- a/src/lib/form-cache.ts
+++ b/src/lib/form-cache.ts
@@ -1,7 +1,7 @@
-import type { NeedInsert } from "@/lib/queries";
+import type { NeedInsert, DonationInsert, PurchaseInsert, HazardInsert } from "@/lib/queries";
 
 const DB_NAME = "luaid-forms";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const OPTIONS_STORE = "options";
 const OUTBOX_STORE = "outbox";
 
@@ -10,10 +10,11 @@ type CachedOptions<T> = {
   updatedAt: number;
 };
 
-type OutboxEntry = {
-  payload: NeedInsert;
-  createdAt: number;
-};
+type OutboxEntry =
+  | { type: "need"; payload: NeedInsert; createdAt: number }
+  | { type: "donation"; payload: DonationInsert; createdAt: number }
+  | { type: "purchase"; payload: PurchaseInsert; createdAt: number }
+  | { type: "hazard"; payload: HazardInsert; photo?: Blob; createdAt: number };
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -78,36 +79,35 @@ export async function setCachedOptions<T>(
 
 // --- Outbox ---
 
-export async function addToOutbox(payload: NeedInsert): Promise<void> {
+export async function addToOutbox(entry: Omit<OutboxEntry, "createdAt">): Promise<void> {
   let db: IDBDatabase | null = null;
   try {
     db = await openDB();
     const tx = db.transaction(OUTBOX_STORE, "readwrite");
     const store = tx.objectStore(OUTBOX_STORE);
-    store.add({ payload, createdAt: Date.now() } satisfies OutboxEntry);
+    store.add({ ...entry, createdAt: Date.now() });
   } finally {
     db?.close();
   }
 }
 
 export async function getOutboxEntries(): Promise<
-  { key: IDBValidKey; payload: NeedInsert }[]
+  { key: IDBValidKey; entry: OutboxEntry }[]
 > {
   let db: IDBDatabase | null = null;
   try {
     db = await openDB();
-    return await new Promise<{ key: IDBValidKey; payload: NeedInsert }[]>(
+    return await new Promise<{ key: IDBValidKey; entry: OutboxEntry }[]>(
       (resolve) => {
         const tx = db!.transaction(OUTBOX_STORE, "readonly");
         const store = tx.objectStore(OUTBOX_STORE);
         const request = store.openCursor();
-        const entries: { key: IDBValidKey; payload: NeedInsert }[] = [];
+        const entries: { key: IDBValidKey; entry: OutboxEntry }[] = [];
 
         request.onsuccess = () => {
           const cursor = request.result;
           if (cursor) {
-            const entry = cursor.value as OutboxEntry;
-            entries.push({ key: cursor.key, payload: entry.payload });
+            entries.push({ key: cursor.key, entry: cursor.value as OutboxEntry });
             cursor.continue();
           } else {
             resolve(entries);

--- a/src/lib/outbox-context.tsx
+++ b/src/lib/outbox-context.tsx
@@ -12,7 +12,8 @@ import {
   getOutboxEntries,
   removeFromOutbox,
 } from "@/lib/form-cache";
-import { insertNeed } from "@/lib/queries";
+import { insertNeed, insertDonation, insertPurchase, insertHazard } from "@/lib/queries";
+import { uploadPhoto } from "@/lib/photo";
 
 type OutboxContextValue = {
   pendingCount: number;
@@ -34,10 +35,28 @@ export function OutboxProvider({ children }: { children: ReactNode }) {
     flushingRef.current = true;
     try {
       const entries = await getOutboxEntries();
-      for (const entry of entries) {
+      for (const { key, entry } of entries) {
         try {
-          await insertNeed(entry.payload);
-          await removeFromOutbox(entry.key);
+          switch (entry.type) {
+            case "need":
+              await insertNeed(entry.payload);
+              break;
+            case "donation":
+              await insertDonation(entry.payload);
+              break;
+            case "purchase":
+              await insertPurchase(entry.payload);
+              break;
+            case "hazard":
+              if (entry.photo) {
+                const hazardId = entry.payload.id ?? crypto.randomUUID();
+                const url = await uploadPhoto("photos", `hazards/${hazardId}.jpg`, entry.photo);
+                if (url) entry.payload.photo_url = url;
+              }
+              await insertHazard(entry.payload);
+              break;
+          }
+          await removeFromOutbox(key);
         } catch (err: unknown) {
           const isUniqueViolation =
             err &&
@@ -45,7 +64,7 @@ export function OutboxProvider({ children }: { children: ReactNode }) {
             "code" in err &&
             (err as { code: string }).code === "23505";
           if (isUniqueViolation) {
-            await removeFromOutbox(entry.key);
+            await removeFromOutbox(key);
           }
         }
       }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -58,6 +58,7 @@ export interface NeedInsert {
 }
 
 export interface DonationInsert {
+  id?: string;
   event_id: string;
   organization_id: string;
   donor_name?: string;
@@ -70,6 +71,7 @@ export interface DonationInsert {
 }
 
 export interface PurchaseInsert {
+  id?: string;
   event_id: string;
   organization_id: string;
   cost: number;
@@ -79,6 +81,7 @@ export interface PurchaseInsert {
 }
 
 export interface HazardInsert {
+  id?: string;
   event_id: string;
   description: string;
   photo_url?: string;
@@ -148,6 +151,7 @@ export async function getNeedsMapPoints(eventId: string): Promise<NeedPoint[]> {
 
 export async function insertNeed(need: NeedInsert) {
   const { error } = await supabase.rpc("insert_need", {
+    p_id: need.id ?? null,
     p_event_id: need.event_id,
     p_lat: need.lat,
     p_lng: need.lng,
@@ -307,6 +311,7 @@ export async function getDonationsByOrganization(eventId: string) {
 
 export async function insertDonation(donation: DonationInsert) {
   const { error } = await supabase.rpc("insert_donation", {
+    p_id: donation.id ?? null,
     p_event_id: donation.event_id,
     p_organization_id: donation.organization_id,
     p_type: donation.type,
@@ -364,6 +369,7 @@ export async function getRecentPurchases(eventId: string) {
 
 export async function insertPurchase(purchase: PurchaseInsert) {
   const { error } = await supabase.rpc("insert_purchase", {
+    p_id: purchase.id ?? null,
     p_event_id: purchase.event_id,
     p_organization_id: purchase.organization_id,
     p_cost: purchase.cost,

--- a/supabase/rpc-functions.sql
+++ b/supabase/rpc-functions.sql
@@ -6,13 +6,14 @@
 
 -- Insert a need with its category junction rows
 CREATE OR REPLACE FUNCTION insert_need(
-  p_event_id uuid,
-  p_lat decimal(9,6),
-  p_lng decimal(9,6),
-  p_access_status access_status,
-  p_urgency urgency_level,
-  p_num_people integer,
-  p_contact_name text,
+  p_id uuid DEFAULT gen_random_uuid(),
+  p_event_id uuid DEFAULT NULL,
+  p_lat decimal(9,6) DEFAULT NULL,
+  p_lng decimal(9,6) DEFAULT NULL,
+  p_access_status access_status DEFAULT NULL,
+  p_urgency urgency_level DEFAULT NULL,
+  p_num_people integer DEFAULT NULL,
+  p_contact_name text DEFAULT NULL,
   p_contact_phone text DEFAULT NULL,
   p_notes text DEFAULT NULL,
   p_hub_id uuid DEFAULT NULL,
@@ -21,8 +22,8 @@ CREATE OR REPLACE FUNCTION insert_need(
 DECLARE
   v_need_id uuid;
 BEGIN
-  INSERT INTO needs (event_id, lat, lng, access_status, urgency, num_people, contact_name, contact_phone, notes, hub_id)
-  VALUES (p_event_id, p_lat, p_lng, p_access_status, p_urgency, p_num_people, p_contact_name, p_contact_phone, p_notes, p_hub_id)
+  INSERT INTO needs (id, event_id, lat, lng, access_status, urgency, num_people, contact_name, contact_phone, notes, hub_id)
+  VALUES (p_id, p_event_id, p_lat, p_lng, p_access_status, p_urgency, p_num_people, p_contact_name, p_contact_phone, p_notes, p_hub_id)
   RETURNING id INTO v_need_id;
 
   IF array_length(p_category_ids, 1) > 0 THEN
@@ -36,10 +37,11 @@ $$;
 
 -- Insert a donation with its category junction rows
 CREATE OR REPLACE FUNCTION insert_donation(
-  p_event_id uuid,
-  p_organization_id uuid,
-  p_type donation_type,
-  p_date date,
+  p_id uuid DEFAULT gen_random_uuid(),
+  p_event_id uuid DEFAULT NULL,
+  p_organization_id uuid DEFAULT NULL,
+  p_type donation_type DEFAULT NULL,
+  p_date date DEFAULT NULL,
   p_donor_name text DEFAULT NULL,
   p_donor_type donor_type DEFAULT NULL,
   p_amount decimal(12,2) DEFAULT NULL,
@@ -49,8 +51,8 @@ CREATE OR REPLACE FUNCTION insert_donation(
 DECLARE
   v_donation_id uuid;
 BEGIN
-  INSERT INTO donations (event_id, organization_id, type, date, donor_name, donor_type, amount, notes)
-  VALUES (p_event_id, p_organization_id, p_type, p_date, p_donor_name, p_donor_type, p_amount, p_notes)
+  INSERT INTO donations (id, event_id, organization_id, type, date, donor_name, donor_type, amount, notes)
+  VALUES (p_id, p_event_id, p_organization_id, p_type, p_date, p_donor_name, p_donor_type, p_amount, p_notes)
   RETURNING id INTO v_donation_id;
 
   IF array_length(p_category_ids, 1) > 0 THEN
@@ -64,18 +66,19 @@ $$;
 
 -- Insert a purchase with its category junction rows
 CREATE OR REPLACE FUNCTION insert_purchase(
-  p_event_id uuid,
-  p_organization_id uuid,
-  p_cost decimal(12,2),
-  p_date date,
+  p_id uuid DEFAULT gen_random_uuid(),
+  p_event_id uuid DEFAULT NULL,
+  p_organization_id uuid DEFAULT NULL,
+  p_cost decimal(12,2) DEFAULT NULL,
+  p_date date DEFAULT NULL,
   p_notes text DEFAULT NULL,
   p_category_ids uuid[] DEFAULT '{}'
 ) RETURNS uuid LANGUAGE plpgsql AS $$
 DECLARE
   v_purchase_id uuid;
 BEGIN
-  INSERT INTO purchases (event_id, organization_id, cost, date, notes)
-  VALUES (p_event_id, p_organization_id, p_cost, p_date, p_notes)
+  INSERT INTO purchases (id, event_id, organization_id, cost, date, notes)
+  VALUES (p_id, p_event_id, p_organization_id, p_cost, p_date, p_notes)
   RETURNING id INTO v_purchase_id;
 
   IF array_length(p_category_ids, 1) > 0 THEN


### PR DESCRIPTION
## Summary
- Generalized the offline outbox from needs-only to all four creation forms (need, donation, purchase, hazard) using a discriminated union in IndexedDB
- Added eager reference data caching (active event, organizations, aid categories) at app mount so all forms work offline with populated dropdowns
- Client-generated UUIDs on all forms for idempotent sync — duplicate submissions are silently deduplicated via unique constraint handling
- Hazard form stores compressed photo Blobs in the outbox, uploaded to Supabase Storage during flush
- All forms now show yellow "saved offline" vs green "submitted" success screens with translated messages (en/fil/ilo)

## Supabase Migration Required
Run the updated `supabase/rpc-functions.sql` in the SQL editor before testing — the `insert_need`, `insert_donation`, and `insert_purchase` RPCs now accept an optional `p_id` parameter for client-generated UUIDs.

## Test Plan
- [x] Submit each form type (need, donation, purchase, hazard) while online — green success screen
- [x] Submit each form type while offline (DevTools Network → Offline) — yellow "saved" screen, outbox badge increments
- [x] Go back online after offline submissions — outbox badge clears, data appears in Supabase
- [x] Attach photo to hazard form, submit offline, go online — photo uploads and `photo_url` populates
- [x] Visit map page online, go offline, navigate to report → donation tab — dropdowns populated from cache
- [x] Verify idempotency: submit a need online, note UUID, trigger outbox flush with same UUID — only one row in Supabase