### PR TITLE
feat: hub popup description and notes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -145,7 +145,9 @@
   },
   "HubDetail": {
     "inventory": "Available Categories",
-    "noInventory": "No inventory data"
+    "noInventory": "No inventory data",
+    "notes": "Notes",
+    "noNotes": "No notes yet"
   },
   "HazardDetail": {
     "description": "Description",

--- a/public/locales/fil/translation.json
+++ b/public/locales/fil/translation.json
@@ -16,8 +16,7 @@
     "stories": "Mga kwento",
     "deployments": "Mga deployment",
     "reliefOps": "Relief Ops",
-    "reliefMap": "Mapa",
-    "dashboard": "Dashboard"
+    "reliefMap": "Mapa"
   },
   "Dashboard": {
     "hero": "Koordinasyon ng Tulong sa Komunidad",
@@ -145,7 +144,9 @@
   },
   "HubDetail": {
     "inventory": "Mga Available na Kategorya",
-    "noInventory": "Walang data ng imbentaryo"
+    "noInventory": "Walang data ng imbentaryo",
+    "notes": "Mga Tala",
+    "noNotes": "Wala pang tala"
   },
   "HazardDetail": {
     "description": "Paglalarawan",
@@ -181,7 +182,17 @@
     "submitNeed": "Magsumite ng isang Pangangailangan",
     "reportDonation": "Mag-ulat ng Donasyon",
     "reportPurchase": "Mag-ulat ng isang Pagbili",
-    "reportHazard": "Mag-ulat ng isang Hazard"
+    "reportHazard": "Mag-ulat ng isang Hazard",
+    "optionNeed": "Kailangan",
+    "optionDonation": "Donasyon",
+    "optionPurchase": "Bumili",
+    "optionHazard": "Hazard",
+    "change": "Baguhin",
+    "locationAcquiring": "Kinukuha ang lokasyon...",
+    "locationCaptured": "✓ Nakuha ang lokasyon",
+    "locationUnavailable": "Hindi available ang lokasyon",
+    "retry": "Subukan muli",
+    "shareLocation": "Ibahagi ang lokasyon"
   },
   "DonationForm": {
     "type": "Uri ng Donasyon",

--- a/public/locales/ilo/translation.json
+++ b/public/locales/ilo/translation.json
@@ -16,8 +16,7 @@
     "stories": "Dagiti Estoria",
     "deployments": "Dagiti pannakaipakat",
     "reliefOps": "Relief Ops",
-    "reliefMap": "Mapa",
-    "dashboard": "Dashboard"
+    "reliefMap": "Mapa"
   },
   "Dashboard": {
     "hero": "Koordinasion ti Tulong iti Komunidad",
@@ -145,7 +144,9 @@
   },
   "HubDetail": {
     "inventory": "Dagiti Magun-od a Kategoria",
-    "noInventory": "Awan ti datos ti imbentaryo"
+    "noInventory": "Awan ti datos ti imbentaryo",
+    "notes": "Dagiti Pakaammo",
+    "noNotes": "Awan pay ti nota"
   },
   "HazardDetail": {
     "description": "Panangiladawan",
@@ -181,7 +182,17 @@
     "submitNeed": "Mangisubmitir iti Kasapulan",
     "reportDonation": "Ireport ti Donasion",
     "reportPurchase": "Ireport ti Gatang",
-    "reportHazard": "Ireport ti Peligro"
+    "reportHazard": "Ireport ti Peligro",
+    "optionNeed": "Kasapulan",
+    "optionDonation": "Donasion",
+    "optionPurchase": "Gumatang",
+    "optionHazard": "Bangen",
+    "change": "Baliwan",
+    "locationAcquiring": "Magun-od ti lokasion...",
+    "locationCaptured": "✓ Lokasion a naala",
+    "locationUnavailable": "Saan a magun-od ti lokasion",
+    "retry": "Padasem manen",
+    "shareLocation": "Ibinglay ti lokasion"
   },
   "DonationForm": {
     "type": "Kita ti Donasion",

--- a/src/components/HubDetailPanel.tsx
+++ b/src/components/HubDetailPanel.tsx
@@ -36,13 +36,13 @@ export default function HubDetailPanel({ hub, onClose, variant = "sheet" }: Prop
       {/* Hub name */}
       <h3 className="mb-1 text-lg font-semibold text-neutral-50">{hub.name}</h3>
 
-      {/* Notes */}
-      {hub.notes && (
-        <p className="mb-4 text-sm text-neutral-400">{hub.notes}</p>
+      {/* Description — subtitle */}
+      {hub.description && (
+        <p className="mb-4 text-sm text-neutral-400">{hub.description}</p>
       )}
 
       {/* Inventory — category checklist */}
-      <div>
+      <div className="mb-4">
         <p className="mb-2 text-sm font-medium text-neutral-400">
           {t("HubDetail.inventory")}
         </p>
@@ -60,6 +60,20 @@ export default function HubDetailPanel({ hub, onClose, variant = "sheet" }: Prop
               </div>
             ))}
           </div>
+        )}
+      </div>
+
+      {/* Notes — free-text status/needs */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-neutral-400">
+          {t("HubDetail.notes")}
+        </p>
+        {hub.notes ? (
+          <p className="whitespace-pre-line rounded-lg bg-base/30 px-3 py-2 text-sm text-neutral-50">
+            {hub.notes}
+          </p>
+        ) : (
+          <p className="text-sm text-neutral-400/60">{t("HubDetail.noNotes")}</p>
         )}
       </div>
     </>

--- a/supabase/seed-demo.sql
+++ b/supabase/seed-demo.sql
@@ -33,16 +33,23 @@ ON CONFLICT DO NOTHING;
 -- ============================================================
 INSERT INTO deployment_hubs (id, event_id, name, lat, lng, description, notes) VALUES
   ('c0000000-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000001',
-   'San Juan Municipal Hall', 16.6619, 120.3269, 'Main coordination center', 'Open 24/7 during relief ops'),
+   'San Juan Municipal Hall', 16.6619, 120.3269, 'Main coordination center',
+   'Open 24/7 during relief ops. Running low on hot meals — requesting more rice and canned goods. Volunteers needed for evening shifts. Coordinator: Mayor''s Office, 0917-555-0101.'),
   ('c0000000-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000001',
-   'Bacnotan Community Center', 16.7314, 120.3494, 'Northern relief staging area', NULL),
+   'Bacnotan Community Center', 16.7314, 120.3494, 'Northern relief staging area',
+   'Staging area currently at ~80% capacity. Urgent need for blankets and children''s clothing for evacuees. Contact Brgy. Capt. Reyes at 0917-555-0202.'),
   ('c0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000001',
-   'San Fernando City Hall', 16.6159, 120.3167, 'Provincial capital hub', 'Serves as backup comms center'),
+   'San Fernando City Hall', 16.6159, 120.3167, 'Provincial capital hub',
+   'Serves as backup comms center. Supplies adequate. Looking for volunteers for Saturday and Sunday shifts. Satellite phone available for remote coordination.'),
   ('c0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000001',
-   'Bauang Relief Center', 16.5328, 120.3378, 'Southern relief distribution', NULL),
+   'Bauang Relief Center', 16.5328, 120.3378, 'Southern relief distribution',
+   'Southern distribution point. Drinking water stock lasts ~2 days — resupply requested. Medical team on-site until 6 PM daily. Bridge access OK via truck.'),
   ('c0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000001',
-   'Luna Emergency Shelter', 16.8555, 120.3803, 'Emergency shelter for evacuees', 'Capacity: ~200 people')
-ON CONFLICT DO NOTHING;
+   'Luna Emergency Shelter', 16.8555, 120.3803, 'Emergency shelter for evacuees',
+   'Capacity: ~200 people (currently sheltering 145). Need hygiene kits and additional cots. Road access via 4x4 only after landslide at km 14.')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  notes = EXCLUDED.notes;
 
 -- ============================================================
 -- Hub Inventory (which categories each hub has)


### PR DESCRIPTION
## Summary
- Hub popup now renders `description` as subtitle and `notes` as a labeled free-text section (previously only notes rendered, unlabeled — easy to mistake for description)
- Seed data updated with admin-voice notes for all 5 hubs (current stock, volunteer asks, access info)
- Seed INSERT for hubs switched from `ON CONFLICT DO NOTHING` to `ON CONFLICT (id) DO UPDATE` so re-runs refresh description/notes instead of silently skipping

## Context
Explored adding a structured "hub needs" feature with full lifecycle (pending → verified → in_transit → confirmed), but decided free-text notes is the right abstraction for the demo. Admin-declared hub status doesn't need the verification workflow that community-reported needs require, and YAGNI on the structure until users ask for filtering/aggregation.

## Test plan
- [ ] Apply the hubs upsert SQL to Supabase (via dashboard SQL editor or reseed)
- [ ] Reload `/en` and click each of the 5 hub markers
- [ ] Verify each popup shows: hub name → description subtitle → Available Categories list → Notes section
- [ ] Verify hubs without notes still render cleanly (none in new seed, but "No notes yet" fallback exists)
- [ ] Verify `fil` and `ilo` locales show translated HubDetail labels