### PR TITLE
feat: add periodic and event-driven SW update checks

### DIFF
--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,10 +1,26 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
 
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
 export default function UpdatePrompt() {
   const {
     needRefresh: [needRefresh],
     updateServiceWorker,
-  } = useRegisterSW();
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+
+      setInterval(() => registration.update(), UPDATE_CHECK_INTERVAL_MS);
+
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+          registration.update();
+        }
+      });
+
+      window.addEventListener("online", () => registration.update());
+    },
+  });
 
   if (!needRefresh) return null;
 


### PR DESCRIPTION
## Summary

- Add explicit service worker update checks on an hourly interval, when the tab regains visibility, and when connectivity is restored
- Closes the gap where an SPA's client-side routing suppresses the browser's native SW update triggers (which only fire on full page loads)
- No UI change, no dependency change — 17 lines added to `UpdatePrompt.tsx`

## Why

The browser checks `sw.js` for updates on page load, on full navigation, and via a throttled ~24h timer. Kapwa Help is an SPA using react-router, so internal navigation (map → dashboard, opening a need pin, language switching) never triggers a real page load and therefore never triggers a check. A coordinator who opens the app in the morning and uses it all day without refreshing would see zero update checks.

Three new triggers close that gap:

| Trigger | User scenario it catches |
|---|---|
| `setInterval` every 1h | Long idle sessions (coordinator watching the map) |
| `visibilitychange` → visible | Backgrounded tab resumes focus |
| `online` event | Connectivity restored after offline stretch (high-value in low-connectivity disaster zones) |

Each new trigger funnels into the same `registration.update()` call — no extra prompts fire unless a real deploy has changed `sw.js`.

## Test plan

Verified manually with `npm run build && npm run preview`:

- [x] Baseline: fresh SW registers, status `activated and is running`
- [x] Refresh flow (regression check): edit → rebuild → refresh → banner appears → update applies
- [x] Visibility trigger: edit → rebuild → blur/focus tab → banner appears within ~1s without refreshing
- [x] Online trigger: edit → rebuild → DevTools Network → Offline → No throttling → banner appears within ~1s
- [x] Hourly interval: inspected in code; all three triggers funnel to the same `registration.update()` path verified by the other two tests
- [x] `npm run build` passes
- [x] `npm run lint` passes